### PR TITLE
IBMi: support tables across multiple libraries sharing one journal

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -7,7 +7,9 @@ package io.debezium.connector.db2as400;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -222,6 +224,46 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String getSchema() {
         return config.getString(SCHEMA).toUpperCase();
+    }
+
+    /**
+     * The set of libraries (schemas) to capture, derived from the raw {@code table.include.list}.
+     *
+     * <p>A connector may capture tables spread across several libraries (e.g.
+     * {@code LIB1.T1,LIB2.T2}). Each qualified entry contributes its own library; unqualified
+     * entries fall back to {@link #getSchema()}, which is always included. The library is taken as
+     * the segment before the table name, mirroring {@code As400JdbcConnection.shortIncludes}.</p>
+     *
+     * @return the distinct uppercased libraries, with {@link #getSchema()} first
+     */
+    public Set<String> getCaptureSchemas() {
+        final Set<String> schemas = new LinkedHashSet<>();
+        final String defaultSchema = getSchema();
+        schemas.add(defaultSchema);
+
+        final String includeList = getRawTableIncludeList();
+        if (includeList == null || includeList.isBlank()) {
+            return schemas;
+        }
+        for (String entry : includeList.split(",")) {
+            entry = entry.trim();
+            if (entry.isEmpty()) {
+                continue;
+            }
+            int o = entry.lastIndexOf('.');
+            if (o <= 0) {
+                schemas.add(defaultSchema);
+                continue;
+            }
+            String schemaName = entry.substring(0, o);
+            // Handle the "database.schema.table" form: keep only the schema segment.
+            o = schemaName.lastIndexOf('.');
+            if (o > 0) {
+                schemaName = schemaName.substring(o + 1);
+            }
+            schemas.add(schemaName.toUpperCase());
+        }
+        return schemas;
     }
 
     public Integer getJournalBufferSize() {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2as400;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -73,8 +74,13 @@ public class As400SnapshotChangeEventSource
     @Override
     protected Set<TableId> getAllTableIds(RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext)
             throws Exception {
-        final Set<TableId> tables = jdbcConnection.readTableNames(jdbcConnection.getRealDatabaseName(),
-                connectorConfig.getSchema(), null, new String[]{ "TABLE" });
+        // A single connector may capture tables across several libraries (sharing one journal),
+        // so discover tables in every library referenced by the include list, not just the default.
+        final String databaseName = jdbcConnection.getRealDatabaseName();
+        final Set<TableId> tables = new LinkedHashSet<>();
+        for (final String schema : connectorConfig.getCaptureSchemas()) {
+            tables.addAll(jdbcConnection.readTableNames(databaseName, schema, null, new String[]{ "TABLE" }));
+        }
         return tables;
     }
 

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+/**
+ * Verifies {@link As400ConnectorConfig#getCaptureSchemas()} derives the set of libraries to capture
+ * from the raw {@code table.include.list}, always including the default schema.
+ */
+public class As400ConnectorConfigCaptureSchemasTest {
+
+    private As400ConnectorConfig configWith(String schema, String includeList) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, schema);
+        if (includeList != null) {
+            builder = builder.with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, includeList);
+        }
+        return new As400ConnectorConfig(builder.build());
+    }
+
+    @Test
+    public void unionsLibrariesFromQualifiedIncludeList() {
+        // Given an include list spanning two libraries
+        final As400ConnectorConfig config = configWith("LIB1", "LIB1.T1,LIB2.T2");
+
+        // When deriving the capture schemas
+        // Then both libraries are returned
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB2");
+    }
+
+    @Test
+    public void fallsBackToDefaultSchemaForUnqualifiedEntries() {
+        // Given an include list with no library prefixes
+        final As400ConnectorConfig config = configWith("MYLIB", "T1,T2");
+
+        // Then only the default schema is captured
+        assertThat(config.getCaptureSchemas()).containsExactly("MYLIB");
+    }
+
+    @Test
+    public void normalizesCaseAndDeduplicates() {
+        // Given a mix of cases, a duplicate, and an unqualified entry
+        final As400ConnectorConfig config = configWith("LIB1", "lib2.t1,LIB2.T2,T3");
+
+        // Then libraries are uppercased and deduplicated, with the default schema included
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB2");
+    }
+
+    @Test
+    public void handlesDatabaseSchemaTableForm() {
+        // Given a fully-qualified database.schema.table entry
+        final As400ConnectorConfig config = configWith("LIB1", "MYDB.LIB3.T1");
+
+        // Then only the schema segment is taken as the library
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB3");
+    }
+
+    @Test
+    public void returnsOnlyDefaultSchemaWhenIncludeListAbsent() {
+        // Given no include list
+        final As400ConnectorConfig config = configWith("LIB1", null);
+
+        // Then only the default schema is captured
+        assertThat(config.getCaptureSchemas()).containsExactly("LIB1");
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -152,29 +153,43 @@ public class JournalInfoRetrieval {
         return getOffset(as400, ji);
     }
 
+    /**
+     * Resolve the single journal shared by all included tables.
+     *
+     * <p>Tables may live in several libraries (schemas): each table's journal is resolved using
+     * its own library, so a single connector can capture tables spread across multiple libraries
+     * as long as they all journal to the <em>same</em> journal. The multi-journal case is rejected
+     * because the offset model is single-journal.</p>
+     *
+     * @param schema the connector's default library, used only when {@code includes} is empty
+     * @param includes the qualified table filters (each carries its own library)
+     * @return the journal common to every included table
+     * @throws IllegalStateException if the journal cannot be retrieved, or if the tables span more
+     *         than one journal
+     */
     public JournalInfo getJournal(AS400 as400, String schema, List<FileFilter> includes) throws IllegalStateException {
+        if (includes.isEmpty()) {
+            return getJournal(as400, schema);
+        }
+        final Set<JournalInfo> jis = new HashSet<>();
+        final Set<String> libraries = new TreeSet<>();
         try {
-            if (includes.isEmpty()) {
-                return getJournal(as400, schema);
-            }
-            final Set<JournalInfo> jis = new HashSet<>();
             for (final FileFilter f : includes) {
-                if (!schema.equals(f.schema())) {
-                    throw new IllegalArgumentException(
-                            String.format("schema %s does not match for filter: %s", schema, f));
-                }
-                final JournalInfo ji = getJournal(as400, f.schema(), f.table());
-                jis.add(ji);
+                libraries.add(f.schema());
+                jis.add(getJournal(as400, f.schema(), f.table()));
             }
-            if (jis.size() > 1) {
-                throw new IllegalArgumentException(
-                        String.format("more than one journal for the set of tables journals: %s", jis));
-            }
-            return jis.iterator().next();
         }
         catch (final Exception e) {
             throw new IllegalStateException("unable to retrieve journal details", e);
         }
+        if (jis.size() > 1) {
+            throw new IllegalStateException(String.format(
+                    "tables span more than one journal, which is not supported: a single connector must "
+                            + "capture tables that all journal to the same journal. Libraries requested: %s; "
+                            + "distinct journals found: %s",
+                    libraries, jis));
+        }
+        return jis.iterator().next();
     }
 
     public JournalInfo getJournal(AS400 as400, String schema, String table) throws Exception {

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ibm.as400.access.AS400;
+
+/**
+ * Unit tests for {@link JournalInfoRetrieval#getJournal(AS400, String, List)} covering the
+ * multi-library support: tables spread across libraries are allowed as long as they share a single
+ * journal, and the multi-journal case is rejected with an explicit message.
+ */
+@ExtendWith(MockitoExtension.class)
+class JournalInfoRetrievalGetJournalTest {
+
+    @Mock
+    AS400 as400;
+
+    private final JournalInfo journalA = new JournalInfo("JRN", "JRNLIB", false);
+    private final JournalInfo journalB = new JournalInfo("OTHERJRN", "JRNLIB", false);
+
+    @Test
+    void multipleLibrariesSharingOneJournalResolveToSingleJournal() throws Exception {
+        // Given two tables in two different libraries that both journal to JRN
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB2", "T2");
+
+        // When resolving the journal for the include list
+        final JournalInfo result = retrieval.getJournal(as400, "LIB1",
+                List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB2", "T2")));
+
+        // Then the shared journal is returned without error
+        assertEquals(journalA, result);
+    }
+
+    @Test
+    void multipleLibrariesWithDistinctJournalsFailWithExplicitMessage() throws Exception {
+        // Given two tables in two libraries that journal to different journals
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doReturn(journalB).when(retrieval).getJournal(as400, "LIB2", "T2");
+
+        // When resolving the journal for the include list
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> retrieval.getJournal(as400, "LIB1",
+                        List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB2", "T2"))));
+
+        // Then the failure clearly names the multi-journal situation and the libraries involved
+        assertTrue(ex.getMessage().contains("more than one journal"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("LIB1"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("LIB2"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Context

Fixes Popsink/data-plane#2781 (connector side).

An IBMi source connector (`As400RpcConnector` / `popsink-connect-ibmi-source`) was locked to a **single library** (`DB_SCHEMA`): capturing tables spread across libraries required one connector per library. This PR lets a **single connector capture tables across multiple libraries**, provided they all journal to the **same journal** (common IBMi case).

The multi-journal case (distinct journals per library) stays **out of scope** and now fails with an explicit message.

## Changes

- **`JournalInfoRetrieval.getJournal(as400, schema, includes)`** — drop the per-table `schema.equals(f.schema())` check; **keep** the single-journal guardrail (`jis.size() > 1`) and improve the error to list the requested libraries and the distinct journals found. The guardrail error is now raised outside the `try` so the explicit message isn't re-wrapped by the generic one.
- **`As400ConnectorConfig.getCaptureSchemas()`** (new) — derive the set of libraries from the raw `table.include.list` (`getRawTableIncludeList()`, the source the journal path already uses), always including the default `getSchema()`. Handles qualified / unqualified / `db.schema.table` / duplicates / case.
- **`As400SnapshotChangeEventSource.getAllTableIds()`** — union `readTableNames(...)` across every captured library instead of the default schema only.

## Tests

- `JournalInfoRetrievalGetJournalTest` — multi-library / same journal → single `JournalInfo`, no exception; multi-library / distinct journals → explicit `IllegalStateException` (guardrail regression).
- `As400ConnectorConfigCaptureSchemasTest` — 5 cases on library derivation.

All 7 unit tests green; both modules compile.

## Follow-ups (tracked in data-plane#2781)

- Integration test on PUB400: snapshot + live CDC over two libraries sharing one journal.
- data-plane: contract regression test, JDBC `libraries=` validation, image version bump, UI multi-library support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)