### PR TITLE
Support ad-hoc blocking snapshots in journal streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If the journal is deleted before it is read it will log an error: "Lost journal 
 
 At this point you really need to resync, this does not happen automatically
 
-* Todo needs to support ad-jhoc snapshotting
+Ad-hoc snapshots (both incremental and blocking) are supported via the signalling channel.
 
 ## Memory
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -122,6 +122,18 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
         watchDog.start();
         try {
             while (context.isRunning()) {
+                // Cooperate with the coordinator when an ad-hoc blocking snapshot is requested:
+                // acknowledge the pause so the blocking snapshot can start, then wait for it to
+                // complete before resuming journal streaming. Without this the coordinator's
+                // blocking-snapshot thread waits forever on waitStreamingPaused() and the snapshot
+                // never runs. The check happens between RPC polls, so the pause takes effect after
+                // the current getJournalEntries() call returns (bounded by the watchdog timeout).
+                if (context.isPaused()) {
+                    log.info("Streaming will now pause for an ad-hoc blocking snapshot");
+                    context.streamingPaused();
+                    context.waitSnapshotCompletion();
+                    log.info("Streaming resumed after blocking snapshot");
+                }
                 try {
                     try {
                         switch (dataConnection.getJournalEntries(context, offsetContext,

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -130,8 +130,12 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                 // the current getJournalEntries() call returns (bounded by the watchdog timeout).
                 if (context.isPaused()) {
                     log.info("Streaming will now pause for an ad-hoc blocking snapshot");
+                    // The streaming thread parks in waitSnapshotCompletion() below and stops calling
+                    // watchDog.alive(); suspend the watchdog so it does not interrupt us mid-snapshot.
+                    watchDog.pause();
                     context.streamingPaused();
                     context.waitSnapshotCompletion();
+                    watchDog.resume();
                     log.info("Streaming resumed after blocking snapshot");
                 }
                 try {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/WatchDog.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/WatchDog.java
@@ -13,9 +13,10 @@ import org.slf4j.LoggerFactory;
 public class WatchDog implements Runnable {
     private static final Logger log = LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
 
-    private long lastSeen = System.currentTimeMillis();
+    private volatile long lastSeen = System.currentTimeMillis();
     private final Thread notify;
-    private boolean running = true;
+    private volatile boolean running = true;
+    private volatile boolean paused = false;
     private final long wait;
     private Thread watchDogThread;
 
@@ -31,7 +32,7 @@ public class WatchDog implements Runnable {
             try {
                 Thread.sleep(wait);
                 long now = System.currentTimeMillis();
-                if (now - lastSeen > wait) {
+                if (!paused && now - lastSeen > wait) {
                     log.warn("No update since {} interrupting streaming thread {}", new Date(lastSeen), notify.getName());
                     notify.interrupt();
                 }
@@ -57,5 +58,23 @@ public class WatchDog implements Runnable {
 
     public void alive() {
         lastSeen = System.currentTimeMillis();
+    }
+
+    /**
+     * Suspends interruption while the streaming thread is legitimately idle, e.g. parked waiting
+     * for an ad-hoc blocking snapshot to complete. Without this the watchdog would interrupt the
+     * paused streaming thread after {@code wait} ms and abort the snapshot.
+     */
+    public void pause() {
+        this.paused = true;
+    }
+
+    /**
+     * Resumes interruption monitoring, resetting the activity timer so a long pause does not cause
+     * an immediate interruption on the next check.
+     */
+    public void resume() {
+        this.lastSeen = System.currentTimeMillis();
+        this.paused = false;
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourcePauseTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourcePauseTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+/**
+ * Verifies that {@link As400StreamingChangeEventSource} cooperates with the coordinator's ad-hoc
+ * blocking-snapshot pause handshake, and that it suspends the {@link WatchDog} for the duration of
+ * the snapshot so the parked streaming thread is not interrupted.
+ */
+public class As400StreamingChangeEventSourcePauseTest {
+
+    // the watchdog must fire several times during the simulated snapshot to make this test meaningful
+    private static final int WATCHDOG_TIMEOUT_MS = 50;
+    private static final long SNAPSHOT_DURATION_MS = 300;
+
+    /**
+     * Fake context that requests a pause on the first streaming iteration and simulates a snapshot
+     * that runs longer than the watchdog timeout.
+     */
+    private static final class PausingContext implements ChangeEventSourceContext {
+        private final AtomicInteger runningChecks = new AtomicInteger();
+        private final AtomicInteger pausedChecks = new AtomicInteger();
+        boolean streamingPausedCalled = false;
+        boolean waitSnapshotCompletionCalled = false;
+        boolean interruptedDuringSnapshot = false;
+
+        @Override
+        public boolean isRunning() {
+            // allow exactly one streaming iteration, then stop the loop
+            return runningChecks.getAndIncrement() == 0;
+        }
+
+        @Override
+        public boolean isPaused() {
+            // a blocking snapshot is pending only on the first iteration
+            return pausedChecks.getAndIncrement() == 0;
+        }
+
+        @Override
+        public void streamingPaused() {
+            streamingPausedCalled = true;
+        }
+
+        @Override
+        public void waitSnapshotCompletion() throws InterruptedException {
+            waitSnapshotCompletionCalled = true;
+            try {
+                // stand in for a long blocking snapshot; without WatchDog.pause() the streaming
+                // thread would be interrupted here and the snapshot would be aborted
+                Thread.sleep(SNAPSHOT_DURATION_MS);
+            }
+            catch (InterruptedException e) {
+                interruptedDuringSnapshot = true;
+                throw e;
+            }
+        }
+
+        @Override
+        public void resumeStreaming() {
+        }
+
+        @Override
+        public void waitStreamingPaused() {
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void blockingSnapshotPausesStreamingWithoutWatchdogInterruption() throws Exception {
+        final As400ConnectorConfig config = mock(As400ConnectorConfig.class);
+        when(config.getPollInterval()).thenReturn(Duration.ofMillis(1));
+        when(config.getMaxRetrievalTimeout()).thenReturn(WATCHDOG_TIMEOUT_MS);
+
+        final As400JdbcConnection jdbcConnection = mock(As400JdbcConnection.class);
+        when(jdbcConnection.getRealDatabaseName()).thenReturn("DB");
+
+        final As400RpcConnection dataConnection = mock(As400RpcConnection.class);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any())).thenReturn(RetrievalState.Success);
+
+        final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final As400DatabaseSchema schema = mock(As400DatabaseSchema.class);
+
+        final As400StreamingChangeEventSource source = new As400StreamingChangeEventSource(
+                config, dataConnection, jdbcConnection, dispatcher, errorHandler, Clock.SYSTEM, schema);
+
+        final PausingContext context = new PausingContext();
+        final As400Partition partition = new As400Partition("server");
+        final As400OffsetContext offsetContext = mock(As400OffsetContext.class);
+
+        source.execute(context, partition, offsetContext);
+
+        // the handshake happened: streaming acknowledged the pause and waited for the snapshot
+        assertThat(context.streamingPausedCalled).isTrue();
+        assertThat(context.waitSnapshotCompletionCalled).isTrue();
+        // the watchdog did not interrupt the parked streaming thread mid-snapshot
+        assertThat(context.interruptedDuringSnapshot).isFalse();
+        // streaming actually resumed afterwards (the journal was polled once after the pause)
+        verify(dataConnection, times(1)).getJournalEntries(any(), any(), any(), any());
+    }
+}

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/WatchDogTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/WatchDogTest.java
@@ -6,11 +6,18 @@
 package io.debezium.connector.db2as400;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class WatchDogTest {
     private WatchDog createTestSubject() {
         return new WatchDog(Thread.currentThread(), 10);
+    }
+
+    @AfterEach
+    public void clearInterrupt() {
+        // a watchdog interruption targets the test thread; make sure the flag does not leak between tests
+        Thread.interrupted();
     }
 
     @Test
@@ -25,6 +32,53 @@ public class WatchDogTest {
             thrown = e;
         }
         Assertions.assertThat(thrown).isInstanceOf(InterruptedException.class);
+        testSubject.stop();
+    }
+
+    @Test
+    public void testPausedWatchDogDoesNotInterrupt() throws Exception {
+        final WatchDog testSubject = createTestSubject();
+        testSubject.pause();
+        testSubject.start();
+        Exception thrown = null;
+        try {
+            // far longer than the 10ms timeout: a non-paused watchdog would interrupt us several times over
+            Thread.sleep(200);
+        }
+        catch (final Exception e) {
+            thrown = e;
+        }
+        Assertions.assertThat(thrown).isNull();
+        Assertions.assertThat(Thread.currentThread().isInterrupted()).isFalse();
+        testSubject.stop();
+    }
+
+    @Test
+    public void testResumeReenablesInterrupt() throws Exception {
+        final WatchDog testSubject = createTestSubject();
+        testSubject.pause();
+        testSubject.start();
+
+        // while paused, no interruption happens
+        Exception whilePaused = null;
+        try {
+            Thread.sleep(100);
+        }
+        catch (final Exception e) {
+            whilePaused = e;
+        }
+        Assertions.assertThat(whilePaused).isNull();
+
+        // once resumed, the watchdog interrupts again after the timeout elapses
+        testSubject.resume();
+        Exception afterResume = null;
+        try {
+            Thread.sleep(200);
+        }
+        catch (final Exception e) {
+            afterResume = e;
+        }
+        Assertions.assertThat(afterResume).isInstanceOf(InterruptedException.class);
         testSubject.stop();
     }
 }


### PR DESCRIPTION
Fixes #6. Targets `3.5` (the active branch; `main` currently does not compile against its debezium snapshot).

## Problem

Ad-hoc **blocking** snapshots (`execute-snapshot` signal with `data.type = blocking`) never run. Two connector-side issues:

1. **No pause handshake.** `ChangeEventSourceCoordinator.doBlockingSnapshot()` sets `paused = true` and blocks on `context.waitStreamingPaused()`, released only when the streaming source calls `context.streamingPaused()`. `As400StreamingChangeEventSource.execute()` only checked `context.isRunning()` — it never observed `isPaused()` nor acknowledged the pause, so the coordinator's blocking-snapshot thread waited forever and the snapshot never started.

2. **Watchdog interrupts the paused thread.** Even with the handshake, the IBM i `WatchDog` interrupts the streaming thread after `max.journal.timeout` (default **60s**) of no journal activity. During a blocking snapshot the streaming thread is parked in `waitSnapshotCompletion()` and stops calling `watchDog.alive()`, so the watchdog would interrupt it and abort the snapshot.

## Fix

1. Honour the pause handshake at the top of the streaming loop, suspending the watchdog for the duration:
   ```java
   if (context.isPaused()) {
       watchDog.pause();
       context.streamingPaused();
       context.waitSnapshotCompletion();
       watchDog.resume();
   }
   ```
   The pause takes effect after the in-flight `getJournalEntries()` RPC returns (bounded by the watchdog timeout).

2. Add `WatchDog.pause()`/`resume()` so it stops interrupting while streaming is legitimately parked; `resume()` resets the activity timer to avoid an immediate interrupt.

No change needed in `As400SnapshotChangeEventSource`: `getBlockingSnapshottingTask` (`onDemand = true`) is inherited from `RelationalSnapshotChangeEventSource`, and the `BLOCKING` signal path goes straight to `coordinator.doBlockingSnapshot()`. Incremental ad-hoc snapshots were already working and are unaffected.

README updated to drop the "needs to support ad-hoc snapshotting" TODO.

## Tests (built & green locally against debezium 3.5.0.Final)

```
WatchDogTest                             Tests run: 3, Failures: 0, Errors: 0
As400StreamingChangeEventSourcePauseTest Tests run: 1, Failures: 0, Errors: 0
BUILD SUCCESS
```

- `WatchDogTest`: a paused watchdog does not interrupt; `resume()` re-arms it.
- `As400StreamingChangeEventSourcePauseTest`: `execute()` honours the handshake (`streamingPaused` + `waitSnapshotCompletion`) and is **not** interrupted during a snapshot longer than the watchdog timeout, then resumes polling. This test fails without the watchdog fix (simulated 300ms snapshot vs 50ms watchdog timeout).

## Manual validation checklist (needs a live IBM i)

- [ ] `execute-snapshot` with `type: blocking` pauses journal streaming, snapshots the requested tables, then resumes.
- [ ] A blocking snapshot longer than `max.journal.timeout` completes without the streaming thread being interrupted.
- [ ] Incremental ad-hoc snapshots still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
