### PR TITLE
Decode DATE/TIME columns by their IBM i DATFMT (fixes #11)

### DIFF
--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DateTimeFormatCache.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DateTimeFormatCache.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.ibm.as400.access.AS400Date;
+import com.ibm.as400.access.AS400Time;
+
+/**
+ * Caches the IBM i date/time format and separator for DATE and TIME columns.
+ * <p>
+ * {@link java.sql.DatabaseMetaData#getColumns} exposes the SQL type ({@code DATE}/{@code TIME}) but not the IBM i
+ * {@code DATFMT}/{@code TIMFMT} nor its separator, so the journal decoder cannot tell a {@code *ISO} column from a
+ * {@code *EUR} one. Because the decoder parses raw journal bytes via {@code AS400Structure.toObject}, the
+ * {@link AS400Date}/{@link AS400Time} format must match the file's DDS format both to parse the value <em>and</em> to
+ * size the column correctly within the record structure (e.g. {@code *MDY} is 8 bytes vs {@code *ISO} 10 bytes).
+ * <p>
+ * The format/separator are read from {@code QSYS2.SYSCOLUMNS} and cached per {@code schema.table.column}, mirroring
+ * {@link CcsidCache} and {@link BytesPerChar}.
+ */
+public class DateTimeFormatCache {
+    private static final String GET_FORMATS = "select table_name, system_table_name, column_name, system_column_name, "
+            + "date_format, date_separator, time_format, time_separator "
+            + "FROM qsys2.SYSCOLUMNS where table_schema=? and (system_table_name = ? or table_name = ?)";
+
+    static final Logger log = LoggerFactory.getLogger(DateTimeFormatCache.class);
+
+    private final Map<String, Optional<FormatAndSeparator>> dateMap = new HashMap<>();
+    private final Map<String, Optional<FormatAndSeparator>> timeMap = new HashMap<>();
+    private final Connect<Connection, SQLException> jdbcConnect;
+
+    public DateTimeFormatCache(final Connect<Connection, SQLException> jdbcConnect) {
+        this.jdbcConnect = jdbcConnect;
+    }
+
+    record FormatAndSeparator(int format, Character separator) {
+    }
+
+    /**
+     * @return the per-column {@link AS400Date}, or empty when the format is unknown (no row, null connection or a
+     *         lookup failure) so the caller can fall back to the default {@code *ISO} behaviour.
+     */
+    public Optional<AS400Date> getDate(String schema, String table, String columnName) {
+        return lookup(dateMap, schema, table, columnName)
+                .map(fs -> new AS400Date(fs.format(), fs.separator()));
+    }
+
+    /**
+     * @return the per-column {@link AS400Time}, or empty when the format is unknown (see {@link #getDate}).
+     */
+    public Optional<AS400Time> getTime(String schema, String table, String columnName) {
+        return lookup(timeMap, schema, table, columnName)
+                .map(fs -> new AS400Time(fs.format(), fs.separator()));
+    }
+
+    private Optional<FormatAndSeparator> lookup(Map<String, Optional<FormatAndSeparator>> map, String schema,
+                                                String table, String columnName) {
+        final String canonicalName = String.format("%s.%s.%s", schema, table, columnName);
+        if (map.containsKey(canonicalName)) {
+            return map.get(canonicalName);
+        }
+
+        try {
+            fetchAllFormatsForTable(schema, table);
+        }
+        catch (final Exception e) {
+            log.error("failed to fetch date/time formats for {}.{}", schema, table, e);
+        }
+        // cache the negative result so an unknown column doesn't re-query on every record
+        return map.computeIfAbsent(canonicalName, k -> Optional.empty());
+    }
+
+    private void fetchAllFormatsForTable(String schema, String table) throws SQLException {
+        final Connection con = jdbcConnect.connection();
+        try (PreparedStatement ps = con.prepareStatement(GET_FORMATS)) {
+            ps.setString(1, schema.toUpperCase());
+            ps.setString(2, table.toUpperCase());
+            ps.setString(3, table.toUpperCase());
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    final String longTableName = StringHelpers.safeTrim(rs.getString(1));
+                    final String shortTableName = StringHelpers.safeTrim(rs.getString(2));
+                    final String longColumn = StringHelpers.safeTrim(rs.getString(3));
+                    final String shortColumn = StringHelpers.safeTrim(rs.getString(4));
+                    final String dateFormat = StringHelpers.safeTrim(rs.getString(5));
+                    final String dateSeparator = rs.getString(6);
+                    final String timeFormat = StringHelpers.safeTrim(rs.getString(7));
+                    final String timeSeparator = rs.getString(8);
+
+                    final Optional<FormatAndSeparator> date = mapDateFormat(dateFormat, dateSeparator);
+                    final Optional<FormatAndSeparator> time = mapTimeFormat(timeFormat, timeSeparator);
+
+                    put(dateMap, schema, longTableName, longColumn, date);
+                    put(dateMap, schema, shortTableName, shortColumn, date);
+                    put(timeMap, schema, longTableName, longColumn, time);
+                    put(timeMap, schema, shortTableName, shortColumn, time);
+                }
+            }
+        }
+    }
+
+    private static void put(Map<String, Optional<FormatAndSeparator>> map, String schema, String table, String column,
+                            Optional<FormatAndSeparator> value) {
+        map.put(String.format("%s.%s.%s", schema, table, column), value);
+    }
+
+    /**
+     * Maps a {@code QSYS2.SYSCOLUMNS.DATE_FORMAT} value (e.g. {@code ISO}, {@code EUR}, optionally {@code *}-prefixed)
+     * to its jt400 {@link AS400Date} {@code FORMAT_*} constant. Pure (no connection) so it is unit-testable.
+     */
+    static Optional<FormatAndSeparator> mapDateFormat(String datfmt, String separator) {
+        final Integer format = switch (normalise(datfmt)) {
+            case "ISO" -> AS400Date.FORMAT_ISO;
+            case "USA" -> AS400Date.FORMAT_USA;
+            case "EUR" -> AS400Date.FORMAT_EUR;
+            case "JIS" -> AS400Date.FORMAT_JIS;
+            case "MDY" -> AS400Date.FORMAT_MDY;
+            case "DMY" -> AS400Date.FORMAT_DMY;
+            case "YMD" -> AS400Date.FORMAT_YMD;
+            case "JUL" -> AS400Date.FORMAT_JUL;
+            default -> null;
+        };
+        if (format == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new FormatAndSeparator(format, separator(separator)));
+    }
+
+    /**
+     * Maps a {@code QSYS2.SYSCOLUMNS.TIME_FORMAT} value to its jt400 {@link AS400Time} {@code FORMAT_*} constant.
+     */
+    static Optional<FormatAndSeparator> mapTimeFormat(String timfmt, String separator) {
+        final Integer format = switch (normalise(timfmt)) {
+            case "ISO" -> AS400Time.FORMAT_ISO;
+            case "USA" -> AS400Time.FORMAT_USA;
+            case "EUR" -> AS400Time.FORMAT_EUR;
+            case "JIS" -> AS400Time.FORMAT_JIS;
+            case "HMS" -> AS400Time.FORMAT_HMS;
+            default -> null;
+        };
+        if (format == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new FormatAndSeparator(format, separator(separator)));
+    }
+
+    private static String normalise(String format) {
+        if (format == null) {
+            return "";
+        }
+        final String trimmed = format.trim().toUpperCase();
+        return trimmed.startsWith("*") ? trimmed.substring(1) : trimmed;
+    }
+
+    /**
+     * The catalog stores the separator as a single character; a blank or empty value means "no separator" and is left
+     * to the jt400 default for the format (returned as {@code null}).
+     */
+    private static Character separator(String separator) {
+        if (separator == null || separator.isEmpty() || separator.isBlank()) {
+            return null;
+        }
+        return separator.charAt(0);
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
@@ -46,8 +46,6 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
 
     private final AS400Float8 as400Float8 = new AS400Float8();
     private final AS400Float4 as400Float4 = new AS400Float4();
-    private final AS400Time as400Time = new AS400Time();
-    private final AS400Date as400Date = new AS400Date();
     private final AS400Timestamp as400Timestamp = new AS400Timestamp();
     private final AS400Xml as400Xml = new AS400Xml();
     private final AS400Bin8 as400Bin8 = new AS400Bin8();
@@ -66,6 +64,7 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
     private final SchemaCacheIF schemaCache;
     private final CcsidCache ccsidCache;
     private final BytesPerChar octetLengthCache;
+    private final DateTimeFormatCache dateTimeFormatCache;
 
     public JdbcFileDecoder(Connect<Connection, SQLException> con, String database, SchemaCacheIF schemaCache,
                            int fromCcsid, int toCcsid) {
@@ -75,6 +74,7 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
         this.databaseName = database;
         ccsidCache = new CcsidCache(con, fromCcsid, toCcsid);
         octetLengthCache = new BytesPerChar(con);
+        dateTimeFormatCache = new DateTimeFormatCache(con);
     }
 
     /*
@@ -335,9 +335,21 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
             case "NUMERIC":
                 return new AS400ZonedDecimal(length, precision);
             case "DATE":
-                return as400Date;
+                return dateTimeFormatCache.getDate(schema, table, columnName)
+                        .map(AS400DataType.class::cast)
+                        .orElseGet(() -> {
+                            log.warn("No DATFMT found for DATE column {}.{}.{}, defaulting to *ISO", schema, table,
+                                    columnName);
+                            return new AS400Date();
+                        });
             case "TIME":
-                return as400Time;
+                return dateTimeFormatCache.getTime(schema, table, columnName)
+                        .map(AS400DataType.class::cast)
+                        .orElseGet(() -> {
+                            log.warn("No TIMFMT found for TIME column {}.{}.{}, defaulting to *ISO", schema, table,
+                                    columnName);
+                            return new AS400Time();
+                        });
             case "REAL":
                 return as400Float4;
             case "DOUBLE":

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DateTimeFormatCacheTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/DateTimeFormatCacheTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.jupiter.api.Test;
+
+import com.ibm.as400.access.AS400Date;
+import com.ibm.as400.access.AS400Time;
+
+import io.debezium.ibmi.db2.journal.retrieve.DateTimeFormatCache.FormatAndSeparator;
+
+public class DateTimeFormatCacheTest {
+
+    @Test
+    public void mapsAllDateFormats() {
+        assertEquals(AS400Date.FORMAT_ISO, DateTimeFormatCache.mapDateFormat("ISO", "-").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_USA, DateTimeFormatCache.mapDateFormat("USA", "/").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_EUR, DateTimeFormatCache.mapDateFormat("EUR", ".").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_JIS, DateTimeFormatCache.mapDateFormat("JIS", "-").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_MDY, DateTimeFormatCache.mapDateFormat("MDY", "/").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_DMY, DateTimeFormatCache.mapDateFormat("DMY", "/").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_YMD, DateTimeFormatCache.mapDateFormat("YMD", "/").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_JUL, DateTimeFormatCache.mapDateFormat("JUL", "/").orElseThrow().format());
+    }
+
+    @Test
+    public void mapsAllTimeFormats() {
+        assertEquals(AS400Time.FORMAT_ISO, DateTimeFormatCache.mapTimeFormat("ISO", ".").orElseThrow().format());
+        assertEquals(AS400Time.FORMAT_USA, DateTimeFormatCache.mapTimeFormat("USA", ":").orElseThrow().format());
+        assertEquals(AS400Time.FORMAT_EUR, DateTimeFormatCache.mapTimeFormat("EUR", ".").orElseThrow().format());
+        assertEquals(AS400Time.FORMAT_JIS, DateTimeFormatCache.mapTimeFormat("JIS", ":").orElseThrow().format());
+        assertEquals(AS400Time.FORMAT_HMS, DateTimeFormatCache.mapTimeFormat("HMS", ":").orElseThrow().format());
+    }
+
+    @Test
+    public void acceptsStarPrefixAndIsCaseInsensitive() {
+        assertEquals(AS400Date.FORMAT_EUR, DateTimeFormatCache.mapDateFormat("*EUR", ".").orElseThrow().format());
+        assertEquals(AS400Date.FORMAT_EUR, DateTimeFormatCache.mapDateFormat("eur", ".").orElseThrow().format());
+    }
+
+    @Test
+    public void unknownOrNullFormatIsEmpty() {
+        assertTrue(DateTimeFormatCache.mapDateFormat(null, "-").isEmpty());
+        assertTrue(DateTimeFormatCache.mapDateFormat("", "-").isEmpty());
+        assertTrue(DateTimeFormatCache.mapDateFormat("BOGUS", "-").isEmpty());
+        assertTrue(DateTimeFormatCache.mapTimeFormat(null, ":").isEmpty());
+    }
+
+    @Test
+    public void blankSeparatorBecomesNull() {
+        final FormatAndSeparator blank = DateTimeFormatCache.mapDateFormat("ISO", " ").orElseThrow();
+        assertEquals(null, blank.separator());
+        final FormatAndSeparator empty = DateTimeFormatCache.mapDateFormat("ISO", "").orElseThrow();
+        assertEquals(null, empty.separator());
+        final FormatAndSeparator dot = DateTimeFormatCache.mapDateFormat("EUR", ".").orElseThrow();
+        assertEquals(Character.valueOf('.'), dot.separator());
+    }
+
+    @Test
+    public void getDateReadsCatalogFormatAndSeparator() throws Exception {
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, false);
+        when(rs.getString(1)).thenReturn("ORDERS"); // long table name
+        when(rs.getString(2)).thenReturn("ORDRS"); // system (short) table name
+        when(rs.getString(3)).thenReturn("ORDER_DATE"); // long column name
+        when(rs.getString(4)).thenReturn("ORDDT"); // system (short) column name
+        when(rs.getString(5)).thenReturn("EUR"); // date_format
+        when(rs.getString(6)).thenReturn("."); // date_separator
+        when(rs.getString(7)).thenReturn(null); // time_format
+        when(rs.getString(8)).thenReturn(null); // time_separator
+
+        final PreparedStatement ps = mock(PreparedStatement.class);
+        when(ps.executeQuery()).thenReturn(rs);
+        final Connection con = mock(Connection.class);
+        when(con.prepareStatement(anyString())).thenReturn(ps);
+
+        final DateTimeFormatCache cache = new DateTimeFormatCache(() -> con);
+
+        final AS400Date date = cache.getDate("SCHEMA", "ORDERS", "ORDER_DATE").orElseThrow();
+        assertEquals(AS400Date.FORMAT_EUR, date.getFormat());
+        assertEquals(Character.valueOf('.'), date.getSeparator());
+        // *EUR is dd.MM.yyyy -> 10 bytes; a mismatched *ISO assumption would mis-size the column
+        assertEquals(10, date.getByteLength());
+
+        // short table/column name resolves to the same format; a non-date column stays empty
+        assertEquals(AS400Date.FORMAT_EUR, cache.getDate("SCHEMA", "ORDRS", "ORDDT").orElseThrow().getFormat());
+        assertTrue(cache.getDate("SCHEMA", "ORDERS", "UNKNOWN_COL").isEmpty());
+    }
+
+    @Test
+    public void lookupFailureReturnsEmpty() {
+        // null connection supplier -> NPE inside fetch is swallowed, caller falls back to default
+        final DateTimeFormatCache cache = new DateTimeFormatCache(() -> {
+            throw new java.sql.SQLException("boom");
+        });
+        assertTrue(cache.getDate("SCHEMA", "ORDERS", "ORDER_DATE").isEmpty());
+        assertTrue(cache.getTime("SCHEMA", "ORDERS", "ORDER_TIME").isEmpty());
+    }
+
+    @Test
+    public void negativeLookupIsCached() throws Exception {
+        final ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(false);
+        final PreparedStatement ps = mock(PreparedStatement.class);
+        when(ps.executeQuery()).thenReturn(rs);
+        final Connection con = mock(Connection.class);
+        when(con.prepareStatement(anyString())).thenReturn(ps);
+
+        final int[] calls = { 0 };
+        final DateTimeFormatCache cache = new DateTimeFormatCache(() -> {
+            calls[0]++;
+            return con;
+        });
+
+        assertTrue(cache.getDate("SCHEMA", "ORDERS", "ORDER_DATE").isEmpty());
+        assertTrue(cache.getDate("SCHEMA", "ORDERS", "ORDER_DATE").isEmpty());
+        assertEquals(1, calls[0], "second lookup of the same column must hit the negative cache");
+    }
+}

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoderTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoderTest.java
@@ -203,4 +203,18 @@ public class JdbcFileDecoderTest {
         assertEquals(0, new BigDecimal(123).compareTo((BigDecimal) result[1]));
         assertEquals("ZZ", result[2]);
     }
+
+    @Test
+    public void dateAndTimeFallBackToIsoWhenFormatUnknown() throws Exception {
+        // null connection -> the format cache lookup fails and is swallowed; DATE/TIME must default to *ISO
+        // rather than throwing (preserves prior behaviour for ISO files and never NPEs the decoder).
+        final JdbcFileDecoder decoder = new JdbcFileDecoder(null, null, new SchemaCacheHash(), -1, -1);
+
+        final AS400DataType date = decoder.toDataType("schem", "table", "d", "DATE", 10, 0);
+        assertEquals(AS400DataType.TYPE_DATE, date.getInstanceType());
+        assertEquals(com.ibm.as400.access.AS400Date.FORMAT_ISO, ((com.ibm.as400.access.AS400Date) date).getFormat());
+
+        final AS400DataType time = decoder.toDataType("schem", "table", "t", "TIME", 8, 0);
+        assertEquals(AS400DataType.TYPE_TIME, time.getInstanceType());
+    }
 }


### PR DESCRIPTION
## Problem

`JdbcFileDecoder` decoded **every** `DATE`/`TIME` column with a shared no-arg `AS400Date`/`AS400Time` — i.e. `*ISO` (`yyyy-MM-dd`). For any file whose date columns use a non-ISO format (`*EUR`, `*MDY`, `*DMY`, `*YMD`, `*USA`, `*JIS`, `*JUL`), `AS400Structure.toObject` threw and the change record was **silently dropped** — the connector stayed `live`, offsets kept advancing, dashboards stayed green. Confirmed silent CDC data loss in production (`*EUR` `dd.MM.yyyy` files).

Beyond the failed parse, the format also determines the column's **byte length** in the record structure (`*MDY`=8, `*ISO`=10, `*JUL`=6, …), so a wrong assumption mis-aligns every subsequent column — not just the date.

## Fix

- New `DateTimeFormatCache`, mirroring `CcsidCache`/`BytesPerChar`: reads `DATE_FORMAT`/`DATE_SEPARATOR` and `TIME_FORMAT`/`TIME_SEPARATOR` from `QSYS2.SYSCOLUMNS` (not exposed by `getColumns()`), cached per `schema.table.column`, with long + short name variants and a negative cache.
- `toDataType` builds a **per-column** `AS400Date`/`AS400Time` from the catalog format + separator. Maps `DATFMT` → jt400 `FORMAT_*` constants.
- Falls back to `*ISO` **with a warning log** when the format is unknown (preserves prior behaviour for ISO files; never NPEs).
- Removes the shared mutable `AS400Date`/`AS400Time` statics (aligned with DBZ-9196).

## Tests

`DateTimeFormatCacheTest` (8) — all date/time format mappings, `*` prefix + case-insensitivity, blank-separator→null, catalog read via mocked JDBC (`*EUR`/`.` → `FORMAT_EUR`, separator, **10-byte length**), short-name resolution, lookup-failure→empty, negative-cache. `JdbcFileDecoderTest` extended for the ISO fallback on unknown format. Full module suite green (61).

## To validate before relying on this in prod

- `DATE_FORMAT` semantics for **SQL-defined tables vs DDS-described physical files** — the journaled/on-disk representation must match the applied format (repro case is a DDS `DATFMT(*EUR)` file).
- Real `DATE_SEPARATOR` values and their compatibility with `AS400Date.setSeparator`.

I have no live IBM i instance to run this end-to-end.

## Out of scope (follow-ups)

- Diagnosability: log the offending `schema.table.column` on a decode failure (currently only the value is logged).
- The "swallow + continue" silent-drop behaviour itself (related #9).

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)