### PR TITLE
Support retrieving RRN from journal entries

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
@@ -137,11 +137,12 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
         return sourceInfo.schema();
     }
 
-    public void updateSourceInfo(Instant timestamp) {
+    public void updateSourceInfo(Instant timestamp, BigInteger rrn) {
         sourceInfo.setSourceTime(timestamp);
         sourceInfo.setReceiver(position.getReceiver().name());
         sourceInfo.setReceiverLib(position.getReceiver().library());
         sourceInfo.setSequence(position.getOffset().toString());
+        sourceInfo.setRrn(String.valueOf(rrn));
     }
 
     @Override
@@ -155,6 +156,7 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.setReceiver(position.getReceiver().name());
         sourceInfo.setReceiverLib(position.getReceiver().library());
         sourceInfo.setSequence(position.getOffset().toString());
+        // sourceInfo.setRrn(String.valueOf(rrn));
         // sourceInfo.tableEvent((TableId) collectionId);
     }
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
@@ -156,7 +156,6 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.setReceiver(position.getReceiver().name());
         sourceInfo.setReceiverLib(position.getReceiver().library());
         sourceInfo.setSequence(position.getOffset().toString());
-        // sourceInfo.setRrn(String.valueOf(rrn));
         // sourceInfo.tableEvent((TableId) collectionId);
     }
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SourceInfoStructMaker.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SourceInfoStructMaker.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2as400;
 
 import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_KEY;
 import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_LIBRARY_KEY;
+import static io.debezium.connector.db2as400.SourceInfo.RRN_KEY;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -27,6 +28,7 @@ public class As400SourceInfoStructMaker extends AbstractSourceInfoStructMaker<So
                 // .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(RECEIVER_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(RECEIVER_LIBRARY_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(RRN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
     }
 
@@ -42,6 +44,7 @@ public class As400SourceInfoStructMaker extends AbstractSourceInfoStructMaker<So
         // .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table());
         ret.put(RECEIVER_KEY, sourceInfo.getReceiver());
         ret.put(RECEIVER_LIBRARY_KEY, sourceInfo.getReceiverLib());
+        ret.put(RRN_KEY, sourceInfo.getRrn());
         return ret;
     }
 }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -298,7 +298,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         final Object[] dataBefore = getBefore(tableId);
                         final Object[] dataNext = r.decode(schema.getFileDecoder());
 
-                        offsetContext.updateSourceInfo(eheader.getTime());
+                        offsetContext.updateSourceInfo(eheader.getTime(), eheader.getRelativeRecordNumber());
 
                         final String txId = eheader.getCommitCycle().toString();
 
@@ -333,7 +333,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                     case ADD_ROW1, ADD_ROW2: {
                         // record added
                         final Object[] dataNext = r.decode(schema.getFileDecoder());
-                        offsetContext.updateSourceInfo(eheader.getTime());
+                        offsetContext.updateSourceInfo(eheader.getTime(), eheader.getRelativeRecordNumber());
 
                         final String txId = eheader.getCommitCycle().toString();
 
@@ -370,7 +370,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         // record deleted
                         final Object[] dataBefore = r.decode(schema.getFileDecoder());
 
-                        offsetContext.updateSourceInfo(eheader.getTime());
+                        offsetContext.updateSourceInfo(eheader.getTime(), eheader.getRelativeRecordNumber());
 
                         final String txId = eheader.getCommitCycle().toString();
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SourceInfo.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SourceInfo.java
@@ -24,11 +24,13 @@ public class SourceInfo extends BaseSourceInfo {
     public static final String JOURNAL_KEY = "journal";
     public static final String RECEIVER_KEY = "receiver";
     public static final String RECEIVER_LIBRARY_KEY = "receiver_library";
+    public static final String RRN_KEY = "rrn";
     private Instant sourceTime;
     private String databaseName;
     private String receiver;
     private String receiverLib;
     private String sequence;
+    private String rrn;
 
     protected SourceInfo(As400ConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -74,4 +76,11 @@ public class SourceInfo extends BaseSourceInfo {
         this.sequence = sequence;
     }
 
+    public String getRrn() {
+        return rrn;
+    }
+
+    public void setRrn(String rrn) {
+        this.rrn = rrn;
+    }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/SourceInfoTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/SourceInfoTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2as400;
 
 import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_KEY;
 import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_LIBRARY_KEY;
+import static io.debezium.connector.db2as400.SourceInfo.RRN_KEY;
 import static io.debezium.connector.db2as400.SourceInfo.SEQUENCE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,6 +40,7 @@ public class SourceInfoTest {
         source.setReceiver("RECV008");
         source.setReceiverLib("RCV_LIB");
         source.setSequence("82");
+        source.setRrn("4");
     }
 
     @Test
@@ -72,6 +74,11 @@ public class SourceInfoTest {
     }
 
     @Test
+    public void shouldHaveRRN() {
+        assertThat(source.struct().getString(RRN_KEY)).isEqualTo("4");
+    }
+
+    @Test
     public void schemaIsCorrect() {
         final Schema schema = SchemaBuilder.struct()
                 .name("io.debezium.connector.db2as400.Source")
@@ -87,6 +94,7 @@ public class SourceInfoTest {
                 .field("ts_ns", Schema.OPTIONAL_INT64_SCHEMA)
                 .field(RECEIVER_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(RECEIVER_LIBRARY_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(RRN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
 
         VerifyRecord.assertConnectSchemasAreEqual(null, source.struct().schema(), schema);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeader.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeader.java
@@ -29,10 +29,11 @@ public class EntryHeader {
     private final long pointerHandle;
     private final String receiver;
     private final String receiverLibrary;
+    private final BigInteger relativeRecordNumber;
 
     public EntryHeader(int nextEntryOffset, int nullValueOffest, long entrySpecificDataOffset, BigInteger sequenceNumber, BigInteger systemSequenceNumber,
                        Instant timestamp, char journalCode, String entryType, String objectName, BigInteger commitCycle, int endOffset, long pointerHandle,
-                       String receiver, String receiverLibrary) {
+                       String receiver, String receiverLibrary, BigInteger relativeRecordNumber) {
         super();
         this.nextEntryOffset = nextEntryOffset;
         this.nullValueOffest = nullValueOffest;
@@ -48,15 +49,16 @@ public class EntryHeader {
         this.pointerHandle = pointerHandle;
         this.receiver = StringHelpers.safeTrim(receiver);
         this.receiverLibrary = StringHelpers.safeTrim(receiverLibrary);
+        this.relativeRecordNumber = relativeRecordNumber;
     }
 
     @Override
     public String toString() {
         return String.format(
-                "EntryHeader [nextEntryOffset=%s, nullValueOffest=%s, entrySpecificDataOffset=%s, sequenceNumber=%s, systemSequenceNumber=%s, timestamp=%s, journalCode=%s, entryType=%s, objectName=%s, commitCycle=%s, endOffset=%s, pointerHandle=%s, receiver=%s, receiverLibrary=%s]",
+                "EntryHeader [nextEntryOffset=%s, nullValueOffest=%s, entrySpecificDataOffset=%s, sequenceNumber=%s, systemSequenceNumber=%s, timestamp=%s, journalCode=%s, entryType=%s, objectName=%s, commitCycle=%s, endOffset=%s, pointerHandle=%s, receiver=%s, receiverLibrary=%s, rrn=%s]",
                 nextEntryOffset, nullValueOffest, entrySpecificDataOffset, sequenceNumber, systemSequenceNumber,
                 timestamp, journalCode, entryType, objectName, commitCycle, endOffset, pointerHandle, receiver,
-                receiverLibrary);
+                receiverLibrary, relativeRecordNumber);
     }
 
     public int getLength() {
@@ -146,5 +148,9 @@ public class EntryHeader {
 
     public String getReceiverLibrary() {
         return receiverLibrary;
+    }
+
+    public BigInteger getRelativeRecordNumber() {
+        return relativeRecordNumber;
     }
 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeaderDecoder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeaderDecoder.java
@@ -104,6 +104,7 @@ public class EntryHeaderDecoder {
         char journalCode = ((String) os[17]).charAt(0);
         String entryType = (String) os[18];
         String objectName = (String) os[25];
+        BigInteger relativeRecordNumber = (BigInteger) os[10];
         BigInteger commitCycle = (BigInteger) os[11];
         Long pointerHandle = (Long) os[12];
         int receiverOffset = ((Long) os[5]).intValue();
@@ -136,7 +137,7 @@ public class EntryHeaderDecoder {
         }
         Instant time = (timestamp == null) ? Instant.ofEpochSecond(0) : timestamp.toInstant();
         return new EntryHeader(nextEntryOffset.intValue(), nullEntryOffset.intValue(), entrySpecificDataOffset, sequenceNumber, systemSequenceNumber,
-                time, journalCode, entryType, objectName, commitCycle, endOffset, pointerHandle, receiver[0], receiver[1]);
+                time, journalCode, entryType, objectName, commitCycle, endOffset, pointerHandle, receiver[0], receiver[1], relativeRecordNumber);
 
     }
 

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournalTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournalTest.java
@@ -27,7 +27,7 @@ class RetrieveJournalTest {
         JournalProcessedPosition positionMatches = firstPosition();
         EntryHeader entryHeader = new EntryHeader(-1, -1, -1l, positionMatches.getOffset(), BigInteger.TWO,
                 Instant.ofEpochMilli(2l), 'Z', "UB", "OBJECT", BigInteger.TEN, -1, -1,
-                positionMatches.getReceiver().name(), positionMatches.getReceiver().library());
+                positionMatches.getReceiver().name(), positionMatches.getReceiver().library(), BigInteger.TWO);
         assertTrue(RetrieveJournal.alreadyProcessed(positionMatches, entryHeader), "compare sequence number, library and receiver match");
 
         JournalProcessedPosition positionIncorrectReceiver = new JournalProcessedPosition(BigInteger.ONE, new JournalReceiver("receiverDoesn'tMatch", "receiverLibrary"),
@@ -48,12 +48,12 @@ class RetrieveJournalTest {
         JournalProcessedPosition positionMatches = firstPosition();
         EntryHeader entryHeader = new EntryHeader(-1, -1, -1l, positionMatches.getOffset(), BigInteger.TWO,
                 Instant.ofEpochMilli(2l), 'Z', "UB", "OBJECT", BigInteger.TEN, -1, -1,
-                positionMatches.getReceiver().name(), positionMatches.getReceiver().library());
+                positionMatches.getReceiver().name(), positionMatches.getReceiver().library(), BigInteger.TWO);
         assertTrue(RetrieveJournal.alreadyProcessed(positionMatches, entryHeader), "compare only sequence number, library and receiver empty");
 
         EntryHeader entryHeaderDifferentOffset = new EntryHeader(-1, -1, -1l, positionMatches.getOffset().add(BigInteger.ONE), BigInteger.TWO,
                 Instant.ofEpochMilli(2l), 'Z', "UB", "OBJECT", BigInteger.TEN, -1, -1,
-                "", "");
+                "", "", BigInteger.TWO);
         assertFalse(RetrieveJournal.alreadyProcessed(positionMatches, entryHeaderDifferentOffset), "compare only sequence number, library and receiver empty");
 
     }
@@ -65,14 +65,14 @@ class RetrieveJournalTest {
 
         EntryHeader entryHeader = new EntryHeader(-1, -1, -1l, positionMatchesNotProcessed.getOffset(), BigInteger.TWO,
                 Instant.ofEpochMilli(2l), 'Z', "UB", "OBJECT", BigInteger.TEN, -1, -1,
-                positionMatchesNotProcessed.getReceiver().name(), positionMatchesNotProcessed.getReceiver().library());
+                positionMatchesNotProcessed.getReceiver().name(), positionMatchesNotProcessed.getReceiver().library(), BigInteger.TWO);
 
         assertTrue(RetrieveJournal.alreadyProcessed(positionMatches, entryHeader), "compare sequence number, library and receiver match");
         assertFalse(RetrieveJournal.alreadyProcessed(positionMatchesNotProcessed, entryHeader), "compare sequence number, library and receiver match");
 
         EntryHeader entryHeaderEmptyReceiver = new EntryHeader(-1, -1, -1l, positionMatchesNotProcessed.getOffset(), BigInteger.TWO,
                 Instant.ofEpochMilli(2l), 'Z', "UB", "OBJECT", BigInteger.TEN, -1, -1,
-                "", "");
+                "", "", BigInteger.TWO);
 
         assertTrue(RetrieveJournal.alreadyProcessed(positionMatches, entryHeaderEmptyReceiver), "compare sequence number, library and receiver match");
         assertFalse(RetrieveJournal.alreadyProcessed(positionMatchesNotProcessed, entryHeaderEmptyReceiver), "compare only sequence number, library and receiver empty");


### PR DESCRIPTION
Applique les changements de [debezium/debezium-connector-ibmi#92](https://github.com/debezium/debezium-connector-ibmi/pull/92).

## Objectif
Extrait le RRN (Relative Record Number) depuis l'en-tête du journal via `BinaryFieldDescription` et l'expose comme nouveau champ `rrn` dans `SourceInfo`, renseigné dans `updateSourceInfo` de `As400OffsetContext`.

Cela aide à mieux identifier les enregistrements, en particulier lorsque les clés primaires sont absentes.

## Changements
**journal-parsing**
- `EntryHeader` : nouveau champ `relativeRecordNumber` (constructeur, `toString()`, getter)
- `EntryHeaderDecoder` : lecture de `os[10]` (count/relative record number)

**debezium-connector-ibmi**
- `SourceInfo` : `RRN_KEY`, champ `rrn`, getter/setter
- `As400OffsetContext` : `updateSourceInfo(Instant, BigInteger rrn)`
- `As400SourceInfoStructMaker` : champ `rrn` dans le schéma et le struct
- `As400StreamingChangeEventSource` : passage de `eheader.getRelativeRecordNumber()`

Tests ajustés (`SourceInfoTest`, `RetrieveJournalTest`).

Ref: debezium/dbz#1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)