### PR TITLE
Recover from pruned journal receiver instead of crash-looping (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,37 @@ If running natively import the cert
 
 ## Journals deleted
 
-If the journal is deleted before it is read it will log an error: "Lost journal at position xxx" and reset to the beginning journal
+If the journal is deleted *while streaming* it logs an error ("Lost journal at position xxx") and resets to the earliest available journal receiver.
 
-At this point you really need to resync, this does not happen automatically
+### Stored offset no longer available at startup
 
-Ad-hoc snapshots (both incremental and blocking) are supported via the signalling channel.
+If the connector has been down longer than the source keeps its journal receivers, its committed offset
+points at a receiver that has since been pruned/rotated. On restart the connector cannot resolve that
+position. This is a **non-transient** condition — the receiver will never come back — so retrying the
+engine only delays an inevitable failure.
+
+Two things are done to keep this from turning into a silent crash-loop:
+
+* A pruned receiver is told apart from a transient RPC/connection error. Only the former is treated as
+  "position lost"; a transient failure is retried as before.
+* The `journal.unavailable.position.recovery` option controls what happens when the stored position is
+  gone:
+
+  | value | behaviour |
+  | --- | --- |
+  | `fail` (default) | Stop with a distinct, non-transient error (marker `IBMI_OFFSET_NO_LONGER_AVAILABLE`) so an orchestrator can reset the offset / trigger a snapshot / alert, rather than retry to death. |
+  | `snapshot` | Reset the offset and let the configured `snapshot.mode` take a fresh snapshot to re-establish table state, then resume streaming from the current journal position. Use with `snapshot.mode=initial`/`always`/`when_needed`. |
+  | `earliest` | Reset streaming to the earliest available journal receiver and continue. Intended for streaming-only / `no_data` connectors. Changes between the lost position and the earliest available receiver are **unrecoverable** and a loud warning is logged. |
+
+  Setting `snapshot.mode=when_needed` also triggers Debezium core's own re-snapshot-on-data-error path,
+  which is equivalent to `journal.unavailable.position.recovery=snapshot`.
+
+Data already lost from pruned receivers cannot be recovered via CDC; recovery is about getting the
+connector healthy again, not replaying the gap. Ad-hoc snapshots (both incremental and blocking) are
+also supported via the signalling channel.
+
+> Not to be confused with a stale JDBC connection detected mid-snapshot, which is a connection-liveness
+> issue rather than offset/position recovery.
 
 ## Memory
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -60,6 +60,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     private final CharSequenceTrimMode charSequenceTrimMode;
     private final SnapshotMode snapshotMode;
+    private final UnavailablePositionRecovery unavailablePositionRecovery;
     private final Configuration config;
     private String incrementalTables = "";
 
@@ -145,6 +146,18 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "are CHAR/VARCHAR or other Character sequence types.  Defaults to both to conform to pre-existing " +
                     "functionality.  Options are none, both, leading, trailing.");
 
+    public static final Field UNAVAILABLE_POSITION_RECOVERY = Field.create("journal.unavailable.position.recovery")
+            .withDisplayName("Recovery strategy when the stored journal position is no longer available")
+            .withEnum(UnavailablePositionRecovery.class, UnavailablePositionRecovery.FAIL)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Controls how the connector recovers when its stored journal position points at a receiver "
+                    + "that has been pruned/rotated off the server (typically after downtime longer than the journal "
+                    + "retention). 'fail' (default) stops with a distinct, non-transient error so an orchestrator can "
+                    + "reset the offset or alert; 'snapshot' resets the offset and lets the configured snapshot.mode take "
+                    + "a fresh snapshot to fill the gap; 'earliest' resets streaming to the earliest available journal "
+                    + "receiver and continues, logging that changes between the lost position and the earliest receiver "
+                    + "are unrecoverable.");
+
     public As400ConnectorConfig(Configuration config) {
         // Debezium treats table.include.list as regex (filters + the base snapshot's re-filter via
         // tableIncludeList()), so names with metacharacters like $ are normalized. The journal path
@@ -156,6 +169,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
         this.tableFilters = new As400NormalRelationalTableFilters(normalizeTableIncludeList(config), new SystemTablesPredicate(), tableToString);
         this.charSequenceTrimMode = CharSequenceTrimMode.parse(config.getString(TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE),
                 TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE.defaultValueAsString());
+        this.unavailablePositionRecovery = UnavailablePositionRecovery.parse(
+                config.getString(UNAVAILABLE_POSITION_RECOVERY), UNAVAILABLE_POSITION_RECOVERY.defaultValueAsString());
     }
 
     /** The raw {@code table.include.list} as supplied (e.g. {@code PYP31."$SCHAR"}), for the journal path. */
@@ -203,6 +218,10 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public SnapshotMode getSnapshotMode() {
         return snapshotMode;
+    }
+
+    public UnavailablePositionRecovery getUnavailablePositionRecovery() {
+        return unavailablePositionRecovery;
     }
 
     @Override
@@ -342,7 +361,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static Field.Set ALL_FIELDS = Field.setOf(JdbcConfiguration.HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, SOCKET_TIMEOUT,
             MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, SECURE,
-            DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED);
+            DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
+            UNAVAILABLE_POSITION_RECOVERY);
 
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
@@ -350,7 +370,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                 .type(
                         HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
-                        DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED)
+                        DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
+                        UNAVAILABLE_POSITION_RECOVERY)
                 .connector(
                         SCHEMA_NAME_ADJUSTMENT_MODE)
                 .events(
@@ -457,6 +478,65 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
          */
         public static SnapshotMode parse(String value, String defaultValue) {
             SnapshotMode mode = parse(value);
+            if (mode == null && defaultValue != null) {
+                mode = parse(defaultValue);
+            }
+            return mode;
+        }
+    }
+
+    /**
+     * Recovery strategy applied at startup when the stored journal position points at a receiver that
+     * is no longer available on the server (pruned/rotated).
+     */
+    public enum UnavailablePositionRecovery implements EnumeratedValue {
+
+        /**
+         * Stop with a distinct, non-transient error ({@link OffsetNoLongerAvailableException}) so the
+         * orchestrator can reset the offset / trigger a snapshot / alert. Default; preserves the
+         * pre-existing "do not silently lose data" behaviour, but without a blind crash-loop.
+         */
+        FAIL("fail"),
+
+        /**
+         * Reset the offset and let the configured {@code snapshot.mode} take a fresh snapshot to
+         * re-establish table state, then resume streaming from the current journal position.
+         */
+        SNAPSHOT("snapshot"),
+
+        /**
+         * Reset streaming to the earliest journal receiver still available and continue. Intended for
+         * streaming-only / {@code no_data} connectors; changes between the lost position and the
+         * earliest available receiver are unrecoverable and a loud warning is logged.
+         */
+        EARLIEST("earliest");
+
+        private final String value;
+
+        UnavailablePositionRecovery(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static UnavailablePositionRecovery parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (UnavailablePositionRecovery option : UnavailablePositionRecovery.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        public static UnavailablePositionRecovery parse(String value, String defaultValue) {
+            UnavailablePositionRecovery mode = parse(value);
             if (mode == null && defaultValue != null) {
                 mode = parse(defaultValue);
             }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -28,6 +28,7 @@ import io.debezium.connector.db2as400.metrics.As400StreamingChangeEventSourceMet
 import io.debezium.document.DocumentReader;
 import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
 import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval;
+import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.jdbc.DefaultMainConnectionProvidingConnectionFactory;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
@@ -141,6 +142,10 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         final As400RpcConnection rpcConnection = new As400RpcConnection(connectorConfig, streamingMetrics,
                 shortIncludes, cacheWait);
 
+        // Detect and recover from a stored position whose receiver has been pruned, before Debezium
+        // core turns an unavailable position into a generic crash-loop.
+        applyUnavailablePositionRecovery(connectorConfig, rpcConnection, previousOffsetPartition);
+
         validateSchemaHistory(connectorConfig, rpcConnection::validateLogPosition, previousOffsetPartition, schema,
                 snapshotterService.getSnapshotter());
 
@@ -178,6 +183,44 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         coordinator.start(taskContext, this.queue, metadataProvider);
 
         return coordinator;
+    }
+
+    /**
+     * When the stored journal position points at a receiver that has been pruned off the server, apply
+     * the configured {@link As400ConnectorConfig.UnavailablePositionRecovery} strategy instead of letting
+     * Debezium core throw a generic, retried-to-death engine failure. Transient validation failures are
+     * left to propagate so the engine restart is a legitimate retry.
+     */
+    private void applyUnavailablePositionRecovery(As400ConnectorConfig connectorConfig, As400RpcConnection rpcConnection,
+                                                  Offsets<As400Partition, As400OffsetContext> previousOffsets) {
+        if (!connectorConfig.isLogPositionCheckEnabled()) {
+            return;
+        }
+        final As400ConnectorConfig.UnavailablePositionRecovery mode = connectorConfig.getUnavailablePositionRecovery();
+        for (Map.Entry<As400Partition, As400OffsetContext> entry : previousOffsets) {
+            final As400OffsetContext offset = entry.getValue();
+            if (offset == null || rpcConnection.checkLogPosition(offset) != As400RpcConnection.PositionAvailability.PRUNED) {
+                continue;
+            }
+            switch (mode) {
+                case FAIL:
+                    throw new OffsetNoLongerAvailableException(
+                            "stored journal position " + offset.getPosition() + " is no longer available on the server "
+                                    + "(pruned receiver). Reset the offset and trigger a snapshot, or set "
+                                    + "'" + As400ConnectorConfig.UNAVAILABLE_POSITION_RECOVERY.name() + "' to 'snapshot' or 'earliest' to auto-recover.");
+                case SNAPSHOT:
+                    LOGGER.warn("Stored journal position {} is no longer available (pruned receiver); resetting the offset so "
+                            + "snapshot.mode '{}' can take a fresh snapshot to fill the gap.", offset.getPosition(), connectorConfig.getSnapshotMode().getValue());
+                    previousOffsets.resetOffset(entry.getKey());
+                    break;
+                case EARLIEST:
+                    LOGGER.warn("DATA GAP: stored journal position {} is no longer available (pruned receiver); resetting streaming to "
+                            + "the earliest available journal receiver. Changes between the lost position and the earliest available "
+                            + "receiver are unrecoverable.", offset.getPosition());
+                    offset.setPosition(new JournalProcessedPosition());
+                    break;
+            }
+        }
     }
 
     @Override

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -20,6 +20,7 @@ import com.ibm.as400.access.AS400;
 import com.ibm.as400.access.SecureAS400;
 import com.ibm.as400.access.SocketProperties;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.db2as400.metrics.As400StreamingChangeEventSourceMetrics;
 import io.debezium.ibmi.db2.journal.retrieve.Connect;
@@ -32,6 +33,7 @@ import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveConfig;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveConfigBuilder;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveJournal;
+import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.LostJournalException;
 import io.debezium.ibmi.db2.journal.retrieve.rjne0200.EntryHeader;
 import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
@@ -101,21 +103,53 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
 
     }
 
-    public boolean validateLogPosition(Partition partition, OffsetContext offsetContext, CommonConnectorConfig config) {
-        try {
-            if (offsetContext instanceof As400OffsetContext offset) {
-                if (offset.isPositionSet()) {
-                    JournalReceiverInfo receiver = new JournalReceiverInfo(offset.getPosition().getReceiver(), null, null, Optional.empty());
+    /**
+     * Availability of a stored journal position on the server.
+     */
+    public enum PositionAvailability {
+        /** The receiver referenced by the stored position still exists. */
+        AVAILABLE,
+        /** No position is stored yet (fresh start / blank offset); streaming begins at the earliest receiver. */
+        NOT_SET,
+        /** The receiver has been pruned/rotated off the server; the position can never be resolved again. */
+        PRUNED
+    }
 
-                    DetailedJournalReceiver dr = journalInfoRetrieval.getReceiverDetails(as400, receiver);
-                    return dr != null;
-                }
-            }
+    /**
+     * Classify a stored offset without collapsing every failure mode into a single boolean.
+     * A pruned receiver ({@link PositionAvailability#PRUNED}) is a permanent condition, whereas a
+     * transient RPC/connection failure is rethrown so the caller retries instead of wrongly treating
+     * the position as lost.
+     *
+     * @throws DebeziumException if the position could not be validated for a transient reason
+     */
+    public PositionAvailability checkLogPosition(OffsetContext offsetContext) {
+        return checkLogPosition(journalInfoRetrieval, as400, offsetContext);
+    }
+
+    static PositionAvailability checkLogPosition(JournalInfoRetrieval journalInfoRetrieval, AS400 as400, OffsetContext offsetContext) {
+        if (!(offsetContext instanceof As400OffsetContext offset) || !offset.isPositionSet()) {
+            return PositionAvailability.NOT_SET;
+        }
+        try {
+            JournalReceiverInfo receiver = new JournalReceiverInfo(offset.getPosition().getReceiver(), null, null, Optional.empty());
+            DetailedJournalReceiver dr = journalInfoRetrieval.getReceiverDetails(as400, receiver);
+            return dr != null ? PositionAvailability.AVAILABLE : PositionAvailability.PRUNED;
+        }
+        catch (JournalReceiverNotFoundException e) {
+            // Non-transient: the receiver has been pruned on the source and will never come back.
+            log.warn("stored journal position {} points at a receiver that no longer exists on the server ({})", offsetContext, e.getMessageId());
+            return PositionAvailability.PRUNED;
         }
         catch (Exception e) {
-            log.warn("unable to find journal poisition {}", offsetContext, e);
+            // Transient (connection/RPC): do not misreport as lost, let the caller retry.
+            throw new DebeziumException("transient failure while validating stored journal position " + offsetContext, e);
         }
-        return false;
+    }
+
+    public boolean validateLogPosition(Partition partition, OffsetContext offsetContext, CommonConnectorConfig config) {
+        // AVAILABLE and NOT_SET are both valid starting points; only a pruned receiver is unavailable.
+        return checkLogPosition(offsetContext) != PositionAvailability.PRUNED;
     }
 
     @Override

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/OffsetNoLongerAvailableException.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/OffsetNoLongerAvailableException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import io.debezium.DebeziumException;
+
+/**
+ * Thrown at startup when the stored journal position points at a receiver that has been pruned on
+ * the IBM i and the connector is configured to {@code FAIL} rather than auto-recover.
+ * <p>
+ * This is a <em>non-transient</em> condition: retrying the engine will never make the pruned
+ * receiver reappear, so an orchestrator must reset the offset (and trigger a snapshot) or alert an
+ * operator rather than spend its restart budget. The {@link #ERROR_CODE} marker is stable and
+ * machine-readable so the data-plane can classify this deterministically from the failure message.
+ */
+public class OffsetNoLongerAvailableException extends DebeziumException {
+
+    /** Stable marker an orchestrator can match on; do not change without coordinating with the data-plane. */
+    public static final String ERROR_CODE = "IBMI_OFFSET_NO_LONGER_AVAILABLE";
+
+    public OffsetNoLongerAvailableException(String message) {
+        super(ERROR_CODE + ": " + message);
+    }
+}

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigRecoveryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigRecoveryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.db2as400.As400ConnectorConfig.UnavailablePositionRecovery;
+
+class As400ConnectorConfigRecoveryTest {
+
+    private static As400ConnectorConfig config(String recovery) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX");
+        if (recovery != null) {
+            builder.with(As400ConnectorConfig.UNAVAILABLE_POSITION_RECOVERY, recovery);
+        }
+        return new As400ConnectorConfig(builder.build());
+    }
+
+    @Test
+    void defaultsToFail() {
+        assertThat(config(null).getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.FAIL);
+    }
+
+    @Test
+    void parsesConfiguredValues() {
+        assertThat(config("snapshot").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.SNAPSHOT);
+        assertThat(config("earliest").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.EARLIEST);
+        assertThat(config("EARLIEST").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.EARLIEST);
+    }
+
+    @Test
+    void invalidValueFallsBackToDefault() {
+        assertThat(config("bogus").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.FAIL);
+    }
+}

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400RpcConnectionLogPositionTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400RpcConnectionLogPositionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import com.ibm.as400.access.AS400;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.db2as400.As400RpcConnection.PositionAvailability;
+import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval;
+import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
+import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+
+/**
+ * Verifies that {@link As400RpcConnection#checkLogPosition} tells apart a permanently pruned journal
+ * receiver from a transient validation failure, instead of collapsing every error into "unavailable".
+ */
+class As400RpcConnectionLogPositionTest {
+
+    private final AS400 as400 = mock(AS400.class);
+
+    private static As400ConnectorConfig config() {
+        return new As400ConnectorConfig(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .build());
+    }
+
+    private static As400OffsetContext offsetWithPosition() {
+        return new As400OffsetContext(config(), new JournalProcessedPosition(
+                BigInteger.valueOf(82), new JournalReceiver("RECV008", "RCV_LIB"), Instant.ofEpochSecond(123_456L), true));
+    }
+
+    @Test
+    void existingReceiverIsAvailable() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceiverDetails(any(), any())).thenReturn(mock(DetailedJournalReceiver.class));
+
+        assertThat(As400RpcConnection.checkLogPosition(retrieval, as400, offsetWithPosition()))
+                .isEqualTo(PositionAvailability.AVAILABLE);
+    }
+
+    @Test
+    void prunedReceiverIsReportedAsPruned() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceiverDetails(any(), any()))
+                .thenThrow(new JournalReceiverNotFoundException("Object RECV008 in library RCV_LIB not found.", "CPF9801"));
+
+        assertThat(As400RpcConnection.checkLogPosition(retrieval, as400, offsetWithPosition()))
+                .isEqualTo(PositionAvailability.PRUNED);
+    }
+
+    @Test
+    void transientFailureIsRethrownNotReportedAsPruned() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceiverDetails(any(), any())).thenThrow(new Exception("connection reset"));
+
+        assertThatThrownBy(() -> As400RpcConnection.checkLogPosition(retrieval, as400, offsetWithPosition()))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("transient");
+    }
+
+    @Test
+    void blankPositionIsNotSet() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        final As400OffsetContext blank = new As400OffsetContext(config(), new JournalProcessedPosition());
+
+        assertThat(As400RpcConnection.checkLogPosition(retrieval, as400, blank))
+                .isEqualTo(PositionAvailability.NOT_SET);
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -38,6 +38,7 @@ import com.ibm.as400.access.ProgramParameter;
 import com.ibm.as400.access.QSYSObjectPathName;
 import com.ibm.as400.access.ServiceProgramCall;
 
+import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
 import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
 import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalReceiverInfo;
 import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalStatus;
@@ -54,6 +55,19 @@ public class JournalInfoRetrieval {
     private static final Logger log = LoggerFactory.getLogger(JournalInfoRetrieval.class);
 
     public static final String JOURNAL_SERVICE_LIB = "/QSYS.LIB/QJOURNAL.SRVPGM";
+
+    /**
+     * IBM i message ids that identify a permanently missing object (typically a pruned journal
+     * receiver or its library). When a service program call fails with one of these, the stored
+     * position is gone for good and the failure must be treated as non-transient rather than retried.
+     * <ul>
+     * <li>CPF9801 - Object &amp;2 in library &amp;3 not found</li>
+     * <li>CPF9810 - Library &amp;1 not found</li>
+     * <li>CPF9812 - File &amp;1 in library &amp;2 not found</li>
+     * <li>CPF7025 - Object cannot be found (journal API)</li>
+     * </ul>
+     */
+    static final Set<String> RECEIVER_NOT_FOUND_MESSAGE_IDS = Set.of("CPF9801", "CPF9810", "CPF9812", "CPF7025");
 
     private static final byte[] EMPTY_AS400_TEXT = new AS400Text(0).toBytes("");
     private final AS400Text as400Text8 = new AS400Text(8);
@@ -506,10 +520,7 @@ public class JournalInfoRetrieval {
             return processor.process(parameters);
         }
         else {
-            final String msg = Arrays.asList(spc.getMessageList()).stream().map(AS400Message::getText).reduce("",
-                    (a, s) -> a + s);
-            log.error(String.format("service program %s/%s call failed %s", programLibrary, program, msg));
-            throw new Exception(msg);
+            throw classifyServiceProgramFailure(programLibrary, program, spc.getMessageList());
         }
     }
 
@@ -529,6 +540,25 @@ public class JournalInfoRetrieval {
             throws Exception {
         return callServiceProgramParams(as400, programLibrary, program, parameters,
                 p -> processor.process(p[0].getOutputData()));
+    }
+
+    /**
+     * Build the exception for a failed service program call, distinguishing a permanently missing
+     * object (pruned receiver / library -> {@link JournalReceiverNotFoundException}) from any other,
+     * potentially transient, failure (generic {@link Exception}).
+     */
+    static Exception classifyServiceProgramFailure(String programLibrary, String program, AS400Message[] messages) {
+        final String msg = Arrays.stream(messages).map(AS400Message::getText).reduce("", (a, s) -> a + s);
+        log.error(String.format("service program %s/%s call failed %s", programLibrary, program, msg));
+        final Optional<String> notFoundId = Arrays.stream(messages)
+                .map(AS400Message::getID)
+                .filter(id -> id != null && RECEIVER_NOT_FOUND_MESSAGE_IDS.contains(id.toUpperCase()))
+                .findFirst();
+        if (notFoundId.isPresent()) {
+            // Non-transient: the referenced object (pruned receiver / library) is gone for good.
+            return new JournalReceiverNotFoundException(msg, notFoundId.get());
+        }
+        return new Exception(msg);
     }
 
     public Integer decodeInt(byte[] data, int offset) {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/JournalReceiverNotFoundException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/JournalReceiverNotFoundException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve.exception;
+
+/**
+ * Raised when a journal receiver referenced by a stored position no longer exists on the server
+ * (it has been rotated/pruned on the IBM i). This is a <em>non-transient</em> condition: the
+ * receiver will never come back, so callers must not treat it as a retriable error. It is kept
+ * distinct from a transient RPC/connection failure so that startup recovery can react
+ * deterministically instead of crash-looping.
+ */
+public class JournalReceiverNotFoundException extends FatalException {
+
+    /** IBM i message id that identified the object-not-found condition (may be {@code null}). */
+    private final String messageId;
+
+    public JournalReceiverNotFoundException(String message) {
+        this(message, null);
+    }
+
+    public JournalReceiverNotFoundException(String message, String messageId) {
+        super(message);
+        this.messageId = messageId;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+}

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalErrorClassificationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalErrorClassificationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import com.ibm.as400.access.AS400Message;
+
+import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
+
+class JournalInfoRetrievalErrorClassificationTest {
+
+    private static AS400Message message(String id, String text) {
+        final AS400Message m = mock(AS400Message.class);
+        lenient().when(m.getID()).thenReturn(id);
+        lenient().when(m.getText()).thenReturn(text);
+        return m;
+    }
+
+    @Test
+    void objectNotFoundIsClassifiedAsReceiverNotFound() {
+        final AS400Message[] messages = { message("CPF9801", "Object RCV0001 in library JRNLIB not found.") };
+
+        final Exception e = JournalInfoRetrieval.classifyServiceProgramFailure(
+                JournalInfoRetrieval.JOURNAL_SERVICE_LIB, "QjoRtvJrnReceiverInformation", messages);
+
+        assertInstanceOf(JournalReceiverNotFoundException.class, e);
+        assertEquals("CPF9801", ((JournalReceiverNotFoundException) e).getMessageId());
+        assertTrue(e.getMessage().contains("RCV0001"));
+    }
+
+    @Test
+    void notFoundMessageIdIsCaseInsensitive() {
+        final AS400Message[] messages = { message("cpf9810", "Library JRNLIB not found.") };
+
+        final Exception e = JournalInfoRetrieval.classifyServiceProgramFailure(
+                JournalInfoRetrieval.JOURNAL_SERVICE_LIB, "QjoRtvJrnReceiverInformation", messages);
+
+        assertInstanceOf(JournalReceiverNotFoundException.class, e);
+    }
+
+    @Test
+    void notFoundIsDetectedAmongOtherMessages() {
+        final AS400Message[] messages = {
+                message("CPF1234", "Some diagnostic."),
+                message("CPF9801", "Object RCV0001 in library JRNLIB not found.")
+        };
+
+        final Exception e = JournalInfoRetrieval.classifyServiceProgramFailure(
+                JournalInfoRetrieval.JOURNAL_SERVICE_LIB, "QjoRtvJrnReceiverInformation", messages);
+
+        assertInstanceOf(JournalReceiverNotFoundException.class, e);
+    }
+
+    @Test
+    void otherFailureStaysTransient() {
+        final AS400Message[] messages = { message("CPF9999", "Function check.") };
+
+        final Exception e = JournalInfoRetrieval.classifyServiceProgramFailure(
+                JournalInfoRetrieval.JOURNAL_SERVICE_LIB, "QjoRtvJrnReceiverInformation", messages);
+
+        assertFalse(e instanceof JournalReceiverNotFoundException);
+        assertEquals(Exception.class, e.getClass());
+    }
+}


### PR DESCRIPTION
Closes #14.

## Problem

When a connector has been down longer than the source keeps its journal receivers, the committed offset points at a receiver that has since been pruned/rotated on the IBM i. On restart the connector cannot resolve that position and dies in a crash-loop.

Two root defects:

1. `As400RpcConnection.validateLogPosition` caught **every** exception and returned `false`, so a genuinely pruned receiver and a transient RPC/connection blip were indistinguishable — dangerous in both directions (a transient blip could trigger a full re-snapshot, or kill a `no_data` connector permanently).
2. There was **no recovery strategy** at startup: Debezium core turned the unavailable position into a generic `DebeziumException`, retried to death by the engine wrapper. Meanwhile the *streaming* path already recovers from a lost journal (`getJournalEntries` on `LostJournalException` resets to the earliest receiver) — the startup path just never did.

## Changes

- **journal-parsing** — classify service-program failures by IBM i message id: `QjoRtvJrnReceiverInformation` failing with an object-not-found id (`CPF9801/9810/9812/7025`) now raises a typed, non-transient `JournalReceiverNotFoundException`; anything else stays a generic (transient) `Exception`.
- **connector** — `validateLogPosition` / new `checkLogPosition` distinguish `AVAILABLE` / `NOT_SET` / `PRUNED`. A pruned receiver is reported unavailable; a transient failure is **rethrown** as `DebeziumException` so the engine retry is legitimate rather than a misreport.
- **connector** — new `journal.unavailable.position.recovery` option applied at startup (before core validation, gated by `log.position.check.enable`):
  - `fail` (default): stop with a distinct `OffsetNoLongerAvailableException` carrying the stable marker `IBMI_OFFSET_NO_LONGER_AVAILABLE`, so the data-plane orchestrator can react deterministically instead of watching a retry-to-dead.
  - `snapshot`: reset the offset and let `snapshot.mode` take a fresh snapshot to fill the gap.
  - `earliest`: reset streaming to the earliest available receiver (reuses the existing `ReceiverPagination` "from beginning" path) with a loud data-gap warning — for streaming-only / `no_data` connectors.
- **docs** — expanded README "Journals deleted" section (mode table, note distinguishing this from the stale-JDBC-mid-snapshot case in #12).

## Tests

New unit tests (all green, 107 total across both modules):
- `JournalInfoRetrievalErrorClassificationTest` — message-id → exception mapping.
- `As400RpcConnectionLogPositionTest` — available / pruned / transient-rethrow / not-set.
- `As400ConnectorConfigRecoveryTest` — default + parsing of the new option.

Data already lost from pruned receivers cannot be recovered via CDC; recovery here is about getting the connector healthy again, not replaying the gap.

## Follow-up (not in this PR)

Companion data-plane work in `popsink_connect` to classify `IBMI_OFFSET_NO_LONGER_AVAILABLE` as non-transient (skip the 5× restart budget). To be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)