### PR TITLE
Hint blocking-snapshot boundary probe with OPTIMIZE FOR 1 ROW (#21)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -411,4 +411,15 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                 additionalCondition, orderBy, tableAlias) + " OPTIMIZE FOR " + limit + " ROWS";
     }
 
+    @Override
+    public String buildSelectPrimaryKeyBoundaries(TableId tableId, long size, String projection, String orderBy) {
+        // DB2 for i: the blocking-snapshot chunk boundary probe orders by the chunk key (often
+        // unindexed) with a large OFFSET. Without a hint the Predictive Query Governor estimates a
+        // full sort and can reject the query with SQL0666 on large tables (issue #21). The probe
+        // fetches a single boundary row, so OPTIMIZE FOR 1 ROW steers the optimizer toward a
+        // first-row plan and keeps the estimate under QQRYTIMLMT. Mirrors the buildSelectWithRowLimits
+        // hint used for incremental chunks above.
+        return super.buildSelectPrimaryKeyBoundaries(tableId, size, projection, orderBy) + " OPTIMIZE FOR 1 ROW";
+    }
+
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionQueryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionQueryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.TableId;
+
+/**
+ * Verifies the DB2 for i query-governor hints the connector appends to the snapshot queries built by
+ * Debezium core. Both the incremental chunk query and the blocking-snapshot boundary probe order by
+ * the (often unindexed) chunk key; without an {@code OPTIMIZE FOR} hint the Predictive Query Governor
+ * can reject them with {@code SQL0666} on large tables (issue #21).
+ *
+ * <p>These are pure query-string builders (they only concatenate strings and quote identifiers), so
+ * they are exercised through a {@code CALLS_REAL_METHODS} mock — {@link As400JdbcConnection}'s
+ * constructor eagerly resolves the real database name and would otherwise require a live AS400.
+ */
+public class As400JdbcConnectionQueryTest {
+
+    private final As400JdbcConnection connection = mock(As400JdbcConnection.class, CALLS_REAL_METHODS);
+
+    @Test
+    void boundary_probe_is_hinted_with_optimize_for_one_row() {
+        // Given - a boundary probe for a large-table chunk key at a high offset
+        String sql = connection.buildSelectPrimaryKeyBoundaries(
+                new TableId(null, "DTEST", "BIG"), 40_396_206L, "K1, K2, K3, K4", "K1, K2, K3, K4");
+
+        // Then - the core OFFSET/FETCH probe is preserved and steered toward a first-row plan so the
+        // governor estimate stays under QQRYTIMLMT instead of assuming a full sort (SQL0666).
+        assertThat(sql)
+                .contains("ORDER BY K1, K2, K3, K4")
+                .contains("OFFSET 40396206 ROWS FETCH NEXT 1 ROWS ONLY")
+                .endsWith(" OPTIMIZE FOR 1 ROW");
+    }
+
+    @Test
+    void incremental_chunk_query_is_hinted_with_optimize_for_the_chunk_size() {
+        // Given - an incremental snapshot chunk of 50k rows
+        String sql = connection.buildSelectWithRowLimits(
+                new TableId(null, "DTEST", "BIG"), 50_000, "*",
+                Optional.empty(), Optional.empty(), "K1", Optional.empty());
+
+        // Then - the chunk fetch is hinted to a first-n-rows plan sized to the chunk
+        assertThat(sql).endsWith(" OPTIMIZE FOR 50000 ROWS");
+    }
+}


### PR DESCRIPTION
## What

Overrides `As400JdbcConnection.buildSelectPrimaryKeyBoundaries` to append `OPTIMIZE FOR 1 ROW` to the blocking-snapshot chunk **boundary probe**.

## Why

Part of #21. The boundary probe orders by the chunk key (often unindexed) with a large `OFFSET … FETCH NEXT 1 ROW`. Without a hint the IBM i Predictive Query Governor estimates a full sort and can reject it with `SQL0666` on large tables. The probe fetches a single row, so `OPTIMIZE FOR 1 ROW` steers the optimizer toward a first-row plan and keeps the estimate under `QQRYTIMLMT`.

Mirrors the existing `buildSelectWithRowLimits` hint for incremental chunks and the upstream Oracle connector's own `buildSelectPrimaryKeyBoundaries` override.

## Scope

- ✅ **Cause 1a** (boundary probe) — this PR.
- ↪️ **Cause 1b** (chunk **data** query needs `OPTIMIZE FOR`) — has no connector-accessible seam; tracked in #22.
- ↪️ **Cause 2** (failed snapshot reported as completed) — fixed in `popsink_connect` (data-plane), separate PR.

## Test

`As400JdbcConnectionQueryTest` asserts the boundary probe and the incremental chunk query both carry the `OPTIMIZE FOR` hint (uses a `CALLS_REAL_METHODS` mock — `As400JdbcConnection`'s constructor eagerly resolves the DB name and would otherwise need a live AS400). Verified locally (`mvn test -Dtest=As400JdbcConnectionQueryTest`, JDK 25).

## References

- #21 (parent), #22 (chunk data query follow-up), Popsink/data-plane#3042 (downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)