### PR TITLE
Populate source.rrn during the initial snapshot (op=r)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -135,6 +135,22 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "are CHAR/VARCHAR or other Character sequence types.  Defaults to both to conform to pre-existing " +
                     "functionality.  Options are none, both, leading, trailing.");
 
+    public static final boolean DEFAULT_SNAPSHOT_RRN_ENABLED = true;
+
+    /**
+     * When enabled, the initial snapshot query appends the Relative Record Number so {@code op=r}
+     * events carry {@code source.rrn} just like streaming events (#25). Disable it if the extra
+     * {@code RRN()} projection is unwanted; {@code source.rrn} then stays unset for snapshot events.
+     */
+    public static final Field SNAPSHOT_RRN_ENABLED = Field.create("snapshot.rrn")
+            .withDisplayName("Populate source.rrn during snapshot")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Whether the initial snapshot should populate the Relative Record Number (source.rrn) "
+                    + "on op=r events by appending RRN() to the snapshot query. Defaults to true.")
+            .withDefault(DEFAULT_SNAPSHOT_RRN_ENABLED);
+
     public As400ConnectorConfig(Configuration config) {
         super(config, new SystemTablesPredicate(),
                 tableToString, 1, ColumnFilterMode.SCHEMA, false);
@@ -218,6 +234,10 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
         return config.getBoolean(TRANSACTION_MGMT_ENABLED);
     }
 
+    public boolean isSnapshotRrnEnabled() {
+        return config.getBoolean(SNAPSHOT_RRN_ENABLED);
+    }
+
     public JournalProcessedPosition getOffset() {
         final String receiver = config.getString(As400OffsetContext.RECEIVER);
         final String lib = config.getString(As400OffsetContext.RECEIVER_LIBRARY);
@@ -254,7 +274,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static Field.Set ALL_FIELDS = Field.setOf(JdbcConfiguration.HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, SOCKET_TIMEOUT,
             MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, SECURE,
-            DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED);
+            DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
+            SNAPSHOT_RRN_ENABLED);
 
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
@@ -262,7 +283,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                 .type(
                         HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
-                        DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED)
+                        DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
+                        SNAPSHOT_RRN_ENABLED)
                 .connector(
                         SCHEMA_NAME_ADJUSTMENT_MODE)
                 .events(

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
@@ -142,7 +142,17 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.setReceiver(position.getReceiver().name());
         sourceInfo.setReceiverLib(position.getReceiver().library());
         sourceInfo.setSequence(position.getOffset().toString());
-        sourceInfo.setRrn(String.valueOf(rrn));
+        setRrn(rrn);
+    }
+
+    /**
+     * Sets only the Relative Record Number on the source info, leaving the rest of the source
+     * position untouched. Used by the initial snapshot, where {@code event(...)} already stamps the
+     * time/receiver/sequence but does not carry an RRN (#25). Null-safe: a null RRN clears the field
+     * rather than writing the literal string "null".
+     */
+    public void setRrn(BigInteger rrn) {
+        sourceInfo.setRrn(rrn == null ? null : rrn.toString());
     }
 
     @Override

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -5,26 +5,37 @@
  */
 package io.debezium.connector.db2as400;
 
+import java.math.BigInteger;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.db2as400.As400OffsetContext.Loader;
+import io.debezium.connector.db2as400.snapshot.query.SelectAllSnapshotQuery;
 import io.debezium.ibmi.db2.journal.retrieve.JournalPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.EventDispatcher.SnapshotReceiver;
 import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -34,16 +45,26 @@ import io.debezium.snapshot.SnapshotterService;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.spi.snapshot.Snapshotter;
 import io.debezium.util.Clock;
+import io.debezium.util.ColumnUtils;
+import io.debezium.util.Strings;
+import io.debezium.util.Threads;
+import io.debezium.util.Threads.Timer;
 
 public class As400SnapshotChangeEventSource
         extends RelationalSnapshotChangeEventSource<As400Partition, As400OffsetContext> {
     private static final Logger log = LoggerFactory.getLogger(As400SnapshotChangeEventSource.class);
+    // mirrors RelationalSnapshotChangeEventSource.LOG_INTERVAL (private there); used by our row-loop override
+    private static final Duration LOG_INTERVAL = Duration.ofSeconds(10);
 
     private final As400ConnectorConfig connectorConfig;
     private final As400JdbcConnection jdbcConnection;
     private final As400RpcConnection rpcConnection;
     private final As400DatabaseSchema schema;
     protected final SnapshotterService snapshotterService;
+    // Kept locally because the same members are private in RelationalSnapshotChangeEventSource but are
+    // needed by our doCreateDataEventsForTable override (which mirrors the parent's row loop, see #25).
+    private final SnapshotProgressListener<As400Partition> snapshotProgressListener;
+    private final NotificationService<As400Partition, As400OffsetContext> notificationService;
 
     public As400SnapshotChangeEventSource(As400ConnectorConfig connectorConfig, As400RpcConnection rpcConnection,
                                           MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory,
@@ -60,6 +81,8 @@ public class As400SnapshotChangeEventSource
         this.jdbcConnection = jdbcConnectionFactory.mainConnection();
         this.schema = schema;
         this.snapshotterService = snapshotterService;
+        this.snapshotProgressListener = snapshotProgressListener;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -192,6 +215,156 @@ public class As400SnapshotChangeEventSource
                                                  List<String> columns) {
         String fullTableName = String.format("%s.%s", tableId.schema(), tableId.table());
         return snapshotterService.getSnapshotQuery().snapshotQuery(fullTableName, columns);
+    }
+
+    /**
+     * Row loop for the initial snapshot. Mirrors
+     * {@link RelationalSnapshotChangeEventSource#doCreateDataEventsForTable} (debezium 3.6) verbatim
+     * except for the RRN handling below; keep it in sync when upgrading debezium.
+     * <p>
+     * The default snapshot query appends the Relative Record Number as a trailing, non-declared
+     * column (see {@link SelectAllSnapshotQuery}). That column would make {@code ColumnUtils.toArray}
+     * throw, so here we (a) build the {@link ColumnUtils.ColumnArray} from the declared columns only,
+     * stripping the trailing RRN column, and (b) read the RRN out per row and stamp it on the offset
+     * so {@code op=r} events carry {@code source.rrn} exactly like the streaming path (#25). If no RRN
+     * column is present (e.g. a user {@code snapshot.select.statement.overrides}), behaviour is
+     * identical to the parent and {@code source.rrn} stays unset.
+     */
+    @Override
+    protected void doCreateDataEventsForTable(ChangeEventSourceContext sourceContext,
+                                              RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext,
+                                              As400OffsetContext offset, SnapshotReceiver<As400Partition> snapshotReceiver, Table table,
+                                              boolean firstTable, boolean lastTable, int tableOrder, int tableCount, String selectStatement,
+                                              OptionalLong rowCount, Set<TableId> rowCountTablesKeySet, JdbcConnection jdbcConnection)
+            throws InterruptedException, SQLException {
+
+        if (!sourceContext.isRunning()) {
+            throw new InterruptedException("Interrupted while snapshotting table " + table.id());
+        }
+
+        long exportStart = clock.currentTimeInMillis();
+        log.info("Exporting data from table '{}' ({} of {} tables)", table.id(), tableOrder, tableCount);
+
+        notificationService.initialSnapshotNotificationService().notifyTableInProgress(
+                snapshotContext.partition, snapshotContext.offset, table.id().identifier(), rowCountTablesKeySet);
+
+        Instant sourceTableSnapshotTimestamp = getSnapshotSourceTimestamp(jdbcConnection, offset, table.id());
+
+        try (Statement statement = readTableStatement(jdbcConnection, rowCount);
+                ResultSet rs = resultSetForDataEvents(selectStatement, statement)) {
+
+            final ResultSetMetaData metaData = rs.getMetaData();
+            final int resultColumnCount = metaData.getColumnCount();
+            // The RRN is projected as the last column and is not a declared table column.
+            final boolean hasRrnColumn = resultColumnCount > 0
+                    && table.columnWithName(metaData.getColumnName(resultColumnCount)) == null;
+            final int rrnColumnIndex = hasRrnColumn ? resultColumnCount : -1;
+            final ColumnUtils.ColumnArray columnArray = declaredColumnArray(metaData, table,
+                    hasRrnColumn ? resultColumnCount - 1 : resultColumnCount);
+
+            long rows = 0;
+            Timer logTimer = getTableScanLogTimer();
+            boolean hasNext = rs.next();
+
+            if (hasNext) {
+                while (hasNext) {
+                    if (!sourceContext.isRunning()) {
+                        throw new InterruptedException("Interrupted while snapshotting table " + table.id());
+                    }
+
+                    rows++;
+                    final Object[] row = jdbcConnection.rowToArray(table, rs, columnArray);
+                    // read the current row's RRN before rs.next() advances the cursor
+                    final BigInteger rrn = readRrn(rs, rrnColumnIndex);
+
+                    if (logTimer.expired()) {
+                        long stop = clock.currentTimeInMillis();
+                        if (rowCount.isPresent()) {
+                            log.info("\t Exported {} of {} records for table '{}' after {}", rows, rowCount.getAsLong(),
+                                    table.id(), Strings.duration(stop - exportStart));
+                        }
+                        else {
+                            log.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
+                                    Strings.duration(stop - exportStart));
+                        }
+                        snapshotProgressListener.rowsScanned(snapshotContext.partition, table.id(), rows);
+                        logTimer = getTableScanLogTimer();
+                    }
+
+                    hasNext = rs.next();
+                    setSnapshotMarker(offset, firstTable, lastTable, rows == 1, !hasNext);
+
+                    // Stamp the RRN before dispatch. getChangeRecordEmitter -> offset.event(...) re-stamps
+                    // time/receiver/sequence but leaves the RRN untouched, so it flows into this op=r event.
+                    offset.setRrn(rrn);
+                    dispatcher.dispatchSnapshotEvent(snapshotContext.partition, table.id(),
+                            getChangeRecordEmitter(snapshotContext.partition, offset, table.id(), row, sourceTableSnapshotTimestamp),
+                            snapshotReceiver);
+                }
+            }
+            else {
+                setSnapshotMarker(offset, firstTable, lastTable, false, true);
+            }
+
+            log.info("\t Finished exporting {} records for table '{}' ({} of {} tables); total duration '{}'",
+                    rows, table.id(), tableOrder, tableCount, Strings.duration(clock.currentTimeInMillis() - exportStart));
+            snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), rows);
+            notificationService.initialSnapshotNotificationService().notifyCompletedTableSuccessfully(
+                    snapshotContext.partition, snapshotContext.offset, table.id().identifier(), rows, snapshotContext.capturedTables);
+        }
+    }
+
+    /**
+     * Like {@code ColumnUtils.toArray} but maps only the first {@code declaredColumnCount} result-set
+     * columns to declared table columns, ignoring a trailing synthetic column (the RRN). Throws the
+     * same way as core if a mapped column is unknown to the table.
+     */
+    private ColumnUtils.ColumnArray declaredColumnArray(ResultSetMetaData metaData, Table table, int declaredColumnCount)
+            throws SQLException {
+        final Column[] columns = new Column[declaredColumnCount];
+        int greatestColumnPosition = 0;
+        for (int i = 0; i < declaredColumnCount; i++) {
+            final String columnName = metaData.getColumnName(i + 1);
+            columns[i] = table.columnWithName(columnName);
+            if (columns[i] == null) {
+                throw new IllegalArgumentException("Column '" + columnName + "' not found in table '" + table.id() + "', " + table);
+            }
+            greatestColumnPosition = Math.max(greatestColumnPosition, columns[i].position());
+        }
+        return new ColumnUtils.ColumnArray(columns, greatestColumnPosition);
+    }
+
+    /** Reads the Relative Record Number from the given column, or null when absent/SQL NULL. */
+    private BigInteger readRrn(ResultSet rs, int rrnColumnIndex) throws SQLException {
+        if (rrnColumnIndex < 1) {
+            return null;
+        }
+        final long value = rs.getLong(rrnColumnIndex);
+        return rs.wasNull() ? null : BigInteger.valueOf(value);
+    }
+
+    // mirrors the (private) RelationalSnapshotChangeEventSource#setSnapshotMarker
+    private void setSnapshotMarker(As400OffsetContext offset, boolean firstTable, boolean lastTable,
+                                   boolean firstRecordInTable, boolean lastRecordInTable) {
+        if (lastRecordInTable && lastTable) {
+            offset.markSnapshotRecord(SnapshotRecord.LAST);
+        }
+        else if (firstRecordInTable && firstTable) {
+            offset.markSnapshotRecord(SnapshotRecord.FIRST);
+        }
+        else if (lastRecordInTable) {
+            offset.markSnapshotRecord(SnapshotRecord.LAST_IN_DATA_COLLECTION);
+        }
+        else if (firstRecordInTable) {
+            offset.markSnapshotRecord(SnapshotRecord.FIRST_IN_DATA_COLLECTION);
+        }
+        else {
+            offset.markSnapshotRecord(SnapshotRecord.TRUE);
+        }
+    }
+
+    private Timer getTableScanLogTimer() {
+        return Threads.timer(clock, LOG_INTERVAL);
     }
 
     @Override

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQuery.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQuery.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import io.debezium.annotation.ConnectorSpecific;
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.db2as400.As400ConnectorConfig;
 import io.debezium.connector.db2as400.As400RpcConnector;
 import io.debezium.snapshot.spi.SnapshotQuery;
 
@@ -32,6 +33,12 @@ public class SelectAllSnapshotQuery implements SnapshotQuery {
      */
     public static final String RRN_COLUMN_ALIAS = "PS_RRN";
 
+    /**
+     * Whether to append the trailing {@code RRN()} column (see {@link #snapshotQuery}). Controlled by
+     * {@link As400ConnectorConfig#SNAPSHOT_RRN_ENABLED}; defaults to its default when unconfigured.
+     */
+    private boolean rrnEnabled = As400ConnectorConfig.DEFAULT_SNAPSHOT_RRN_ENABLED;
+
     @Override
     public String name() {
         return CommonConnectorConfig.SnapshotQueryMode.SELECT_ALL.getValue();
@@ -39,7 +46,10 @@ public class SelectAllSnapshotQuery implements SnapshotQuery {
 
     @Override
     public void configure(Map<String, ?> properties) {
-
+        final Object value = properties.get(As400ConnectorConfig.SNAPSHOT_RRN_ENABLED.name());
+        if (value != null) {
+            this.rrnEnabled = Boolean.parseBoolean(value.toString());
+        }
     }
 
     @Override
@@ -48,6 +58,10 @@ public class SelectAllSnapshotQuery implements SnapshotQuery {
         // if we include single quotes the column names turn into 00001,00002,... which we then can't map to the table
         final String columns = snapshotSelectColumns.stream().map(x -> x.replace("'", "\""))
                 .collect(Collectors.joining(", "));
+        if (!rrnEnabled) {
+            // RRN population disabled: emit the plain projection so source.rrn stays unset for op=r events.
+            return Optional.of("SELECT " + columns + " FROM " + tableId);
+        }
         // Append the Relative Record Number as the last column so op=r snapshot events carry source.rrn
         // just like streaming events do (#25). It must stay last: the snapshot read path strips the
         // trailing, non-declared column before mapping the row back to the table's columns.

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQuery.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQuery.java
@@ -18,6 +18,20 @@ import io.debezium.snapshot.spi.SnapshotQuery;
 @ConnectorSpecific(connector = As400RpcConnector.class)
 public class SelectAllSnapshotQuery implements SnapshotQuery {
 
+    /**
+     * Correlation name given to the snapshotted table so the trailing {@code RRN()} scalar has an
+     * unambiguous table designator to reference. Chosen to be unlikely to clash with a real column.
+     */
+    private static final String TABLE_CORRELATION = "DBZ_T";
+
+    /**
+     * Alias of the synthetic Relative Record Number column appended to the snapshot query (see #25).
+     * It is emitted as the <em>last</em> projected column and is not a declared table column;
+     * {@code As400SnapshotChangeEventSource} reads it out and strips it before the row is mapped to
+     * the table columns.
+     */
+    public static final String RRN_COLUMN_ALIAS = "PS_RRN";
+
     @Override
     public String name() {
         return CommonConnectorConfig.SnapshotQueryMode.SELECT_ALL.getValue();
@@ -32,7 +46,13 @@ public class SelectAllSnapshotQuery implements SnapshotQuery {
     public Optional<String> snapshotQuery(String tableId, List<String> snapshotSelectColumns) {
 
         // if we include single quotes the column names turn into 00001,00002,... which we then can't map to the table
-        return Optional.of(snapshotSelectColumns.stream().map(x -> x.replace("'", "\""))
-                .collect(Collectors.joining(", ", "SELECT ", " FROM " + tableId)));
+        final String columns = snapshotSelectColumns.stream().map(x -> x.replace("'", "\""))
+                .collect(Collectors.joining(", "));
+        // Append the Relative Record Number as the last column so op=r snapshot events carry source.rrn
+        // just like streaming events do (#25). It must stay last: the snapshot read path strips the
+        // trailing, non-declared column before mapping the row back to the table's columns.
+        return Optional.of("SELECT " + columns
+                + ", RRN(" + TABLE_CORRELATION + ") AS \"" + RRN_COLUMN_ALIAS + "\""
+                + " FROM " + tableId + " " + TABLE_CORRELATION);
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQueryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQueryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400.snapshot.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the snapshot query builder, in particular the trailing RRN column added so that
+ * op=r snapshot events carry source.rrn (#25).
+ */
+public class SelectAllSnapshotQueryTest {
+
+    private final SelectAllSnapshotQuery query = new SelectAllSnapshotQuery();
+
+    @Test
+    public void appendsRrnAsTheLastColumnWithACorrelation() {
+        final Optional<String> sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("COL1", "COL2"));
+
+        assertThat(sql).isPresent();
+        assertThat(sql.get())
+                .isEqualTo("SELECT COL1, COL2, RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS
+                        + "\" FROM MYLIB.MYTABLE DBZ_T");
+    }
+
+    @Test
+    public void rrnStaysLastAndTableGetsTheCorrelation() {
+        final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("COL1")).orElseThrow();
+
+        // the RRN scalar must be the final projected column, and must reference the FROM correlation
+        assertThat(sql).endsWith("RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS + "\" FROM MYLIB.MYTABLE DBZ_T");
+        assertThat(sql.indexOf("RRN(")).isGreaterThan(sql.indexOf("COL1"));
+    }
+
+    @Test
+    public void keepsExistingSingleToDoubleQuoteColumnRewrite() {
+        // single quotes would otherwise turn the column names into 00001,00002,...
+        final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("'$SCHAR'", "COL2")).orElseThrow();
+
+        assertThat(sql).startsWith("SELECT \"$SCHAR\", COL2, ");
+        assertThat(sql).contains("RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS + "\"");
+    }
+}

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQueryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/snapshot/query/SelectAllSnapshotQueryTest.java
@@ -8,9 +8,12 @@ package io.debezium.connector.db2as400.snapshot.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+
+import io.debezium.connector.db2as400.As400ConnectorConfig;
 
 /**
  * Unit tests for the snapshot query builder, in particular the trailing RRN column added so that
@@ -45,6 +48,35 @@ public class SelectAllSnapshotQueryTest {
         final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("'$SCHAR'", "COL2")).orElseThrow();
 
         assertThat(sql).startsWith("SELECT \"$SCHAR\", COL2, ");
+        assertThat(sql).contains("RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS + "\"");
+    }
+
+    @Test
+    public void omitsRrnColumnWhenDisabled() {
+        query.configure(Map.of(As400ConnectorConfig.SNAPSHOT_RRN_ENABLED.name(), "false"));
+
+        final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("COL1", "COL2")).orElseThrow();
+
+        assertThat(sql).isEqualTo("SELECT COL1, COL2 FROM MYLIB.MYTABLE");
+        assertThat(sql).doesNotContain("RRN(");
+    }
+
+    @Test
+    public void appendsRrnColumnWhenExplicitlyEnabled() {
+        query.configure(Map.of(As400ConnectorConfig.SNAPSHOT_RRN_ENABLED.name(), "true"));
+
+        final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("COL1")).orElseThrow();
+
+        assertThat(sql).endsWith("RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS + "\" FROM MYLIB.MYTABLE DBZ_T");
+    }
+
+    @Test
+    public void defaultsToAppendingRrnWhenUnconfigured() {
+        // an empty configuration map (property absent) must keep the default behaviour: RRN present
+        query.configure(Map.of());
+
+        final String sql = query.snapshotQuery("MYLIB.MYTABLE", List.of("COL1")).orElseThrow();
+
         assertThat(sql).contains("RRN(DBZ_T) AS \"" + SelectAllSnapshotQuery.RRN_COLUMN_ALIAS + "\"");
     }
 }


### PR DESCRIPTION
Closes #25.

## Problem
`source.rrn` is populated on streaming events (`op=c/u/d`) but was `null` on every initial-snapshot event (`op=r`), because the RRN was only ever set from the streaming path. Downstream consumers that key off the RRN (e.g. persisting it as the `__rrn` metadata column, Popsink/data-plane#3072) had no RRN for the entire initial load.

## Change
Fetch the RRN per row during the snapshot and stamp it on the offset so it flows to `source.rrn`, mirroring the streaming path.

- **`SelectAllSnapshotQuery`** — projects `RRN(DBZ_T) AS "PS_RRN"` as the **last** column, adding a correlation (`DBZ_T`) on the `FROM` so the `RRN()` scalar has a table designator to reference.
- **`As400SnapshotChangeEventSource`** — overrides `doCreateDataEventsForTable` (mirrors debezium 3.6) to:
  - build the `ColumnArray` from the **declared columns only**, so `ColumnUtils.toArray` never throws on the synthetic trailing column (this is the exact mapping caveat flagged in the issue);
  - read the RRN out per row (before `rs.next()` advances) and `offset.setRrn(rrn)` before dispatch — `event()` doesn't touch the RRN, so it survives into the `op=r` record;
  - detect the RRN column **structurally** (trailing non-declared column), so a `snapshot.select.statement.overrides` query with no RRN column falls back to the previous behaviour.
  - Kept local refs to `notificationService`/`snapshotProgressListener` and reimplemented `setSnapshotMarker`/`getTableScanLogTimer` since they are private in the parent (preserves snapshot progress reporting).
- **`As400OffsetContext.setRrn(BigInteger)`** — null-safe, avoids writing the literal `"null"`.
- **`SelectAllSnapshotQueryTest`** — asserts RRN is last, correlation is added, and the `'`→`"` column rewrite is preserved.

## Acceptance criteria (#25)
- [x] `op=r` events carry a non-null `source.rrn` equal to the row's RRN.
- [x] Value uses the same textual form as the streaming path (`BigInteger.toString()`).
- [x] Snapshot row → table-column mapping stays correct (RRN column stripped before mapping).

## ⚠️ Not yet verified
- **Build & tests** — `main` depends on `debezium-parent:3.6.0-SNAPSHOT`, which needs debezium core built from source (or gcloud-authed access to the snapshot registry). Not runnable in the authoring environment.
- **Exact `RRN()` SQL syntax** (qualified name vs correlation) — to validate on a live Db2 for i / PUB400 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)