### PR TITLE
improve logs in As400StreamingChangeEventSource

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -230,6 +230,13 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
     private BlockingReceiverConsumer processJournalEntries(As400Partition partition, As400OffsetContext offsetContext)
             throws IOException, SQLNonTransientConnectionException {
         return (nextOffset, r, eheader) -> {
+            String longName = eheader.getFile();
+            try {
+                longName = jdbcConnection.getLongName(eheader.getLibrary(), eheader.getFile());
+            }
+            catch (final IllegalStateException e) {
+                log.error("failed to look up long name", e);
+            }
             try {
                 final JournalEntryType journalEntryType = eheader.getJournalEntryType();
 
@@ -238,13 +245,6 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                     return;
                 }
 
-                String longName = eheader.getFile();
-                try {
-                    longName = jdbcConnection.getLongName(eheader.getLibrary(), eheader.getFile());
-                }
-                catch (final IllegalStateException e) {
-                    log.error("failed to look up long name", e);
-                }
                 final TableId tableId = new TableId(database, eheader.getLibrary(), longName);
 
                 final boolean includeTable = connectorConfig.getTableFilters().dataCollectionFilter()
@@ -458,7 +458,9 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                 throw e;
             }
             catch (final Exception e) {
-                log.error("Failed to process record", e);
+                log.error("Failed to process record at offset = " + eheader.getSequenceNumber() + "  in table = " + longName +
+                        " at RRN = " + eheader.getRelativeRecordNumber() + " [journalCode = " + eheader.getJournalCode() + ", journalEntryType = " + eheader.getJournalEntryType() + "], " +
+                        "skipping and dumping diagnostics if enabled ...", e);
             }
         };
     }


### PR DESCRIPTION
Logs will be clearer about the location of the decode error.

follow-up
- add this logger to the DLQ interception in popsink_connect/ibmi_source => catching logging event is the only way to handle debezium sources so let's simply add this class logger to the watch list
- enable diagnostic Folder in popsink_connect/ibmi_source (existing feature) and map it to a persistent folder in kube, so individual decode error can be analysed fully even when the connector is off

```   
 public static final Field DIAGNOSTICS_FOLDER = Field.create("diagnostics.folder",
            "folder to dump failed decodings to", "used when there is a decoding failure to aid diagnostics");
```