### PR TITLE
introduce error.tolerance to skip quietly on a invalid table 

### DIFF
--- a/.claude/.headroom_wrap_marker.json
+++ b/.claude/.headroom_wrap_marker.json
@@ -1,0 +1,1 @@
+{"pid": 176951, "start_src": "proc", "start_time": 1813866.0, "port": 8787, "key": "ANTHROPIC_BASE_URL", "previous": null}

--- a/README.md
+++ b/README.md
@@ -125,6 +125,39 @@ are possible while the connector still reports `live` (issue #27): a requested p
 > Not to be confused with a stale JDBC connection detected mid-snapshot, which is a connection-liveness
 > issue rather than offset/position recovery.
 
+## Tables that cannot be captured
+
+A table listed in `table.include.list` cannot be streamed at all when it does not exist, when it has no
+journal (never `STRJRNPF`'d), or when it is an **SQL view** — a view has no journal of its own and the
+IBM i journal RPC calls only accept physical files. Every case below is logged at **ERROR** level.
+
+**A table that does not exist is always dropped**, whatever `errors.tolerance` is set to, because
+Debezium ignores `table.include.list` entries with no matching table everywhere else (the snapshot
+discovers tables from the catalog).
+
+For a table that *does* exist but has no journal, `errors.tolerance` decides:
+
+| value | behaviour |
+| --- | --- |
+| `none` (default) | Startup fails, so the misconfiguration has to be fixed (or the table removed from the include list) rather than silently never streaming. |
+| `all` | The table is left out of the journal filters; the remaining tables stream as usual. |
+
+Two things stay fatal even with `all`, because they are not "one bad table": tables spanning more than
+one journal (the offset model is single-journal), and an include list where *no* table can be captured —
+an empty filter list would otherwise be read as "no include list", i.e. stream the whole library.
+
+Missing tables and views come from `QSYS2.SYSTABLES` before any RPC call (`TABLE_TYPE = 'V'` is a view);
+an unjournaled table shows up when its journal is resolved. That catalog lookup is deliberately loose —
+long or system name, any case, and `SYSTEM_TABLE_NAME` may come back delimited (`"Vue10002"`) — because a
+miss drops the table. If the lookup itself fails the table is kept, so a catalog hiccup cannot silently
+stop a healthy table from being captured.
+
+Snapshots already skipped both (table discovery asks for `TABLE` only), so this is about the streaming
+side.
+
+> `errors.tolerance` is the same property name and the same `none`/`all` values as Kafka Connect's own,
+> which governs converter/transform/producer errors; the setting is shared and the intent is the same.
+
 ## Memory
 
 Recommended minimum memory 1GB

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -61,6 +61,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     private final CharSequenceTrimMode charSequenceTrimMode;
     private final SnapshotMode snapshotMode;
     private final UnavailablePositionRecovery unavailablePositionRecovery;
+    private final ErrorsTolerance errorsTolerance;
     private final Configuration config;
     private String incrementalTables = "";
 
@@ -193,6 +194,17 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "receiver and continues, logging that changes between the lost position and the earliest receiver "
                     + "are unrecoverable.");
 
+    /** Shares Kafka Connect's own {@code errors.tolerance}, so it is left out of {@link #configDef()}. */
+    public static final Field ERRORS_TOLERANCE = Field.create("errors.tolerance")
+            .withDisplayName("Tolerance for tables that cannot be captured")
+            .withEnum(ErrorsTolerance.class, ErrorsTolerance.NONE)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("What to do with a table in 'table.include.list' that exists but has no journal, "
+                    + "either because it was never journaled or because it is an SQL view. 'none' (default) fails "
+                    + "startup; 'all' logs it at ERROR level and captures the remaining tables. A table that does "
+                    + "not exist is always dropped, as Debezium ignores include-list entries with no matching table. "
+                    + "Tables spanning more than one journal, or none of them being capturable, always fails.");
+
     public As400ConnectorConfig(Configuration config) {
         // Debezium treats table.include.list as regex (filters + the base snapshot's re-filter via
         // tableIncludeList()), so names with metacharacters like $ are normalized. The journal path
@@ -206,6 +218,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                 TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE.defaultValueAsString());
         this.unavailablePositionRecovery = UnavailablePositionRecovery.parse(
                 config.getString(UNAVAILABLE_POSITION_RECOVERY), UNAVAILABLE_POSITION_RECOVERY.defaultValueAsString());
+        this.errorsTolerance = ErrorsTolerance.parse(config.getString(ERRORS_TOLERANCE), ERRORS_TOLERANCE.defaultValueAsString());
     }
 
     /** The raw {@code table.include.list} as supplied (e.g. {@code PYP31."$SCHAR"}), for the journal path. */
@@ -257,6 +270,14 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public UnavailablePositionRecovery getUnavailablePositionRecovery() {
         return unavailablePositionRecovery;
+    }
+
+    /**
+     * Whether an included table that exists but has no journal should be skipped with a loud ERROR instead
+     * of failing startup. A table that does not exist is dropped regardless.
+     */
+    public boolean skipUncapturableTables() {
+        return errorsTolerance == ErrorsTolerance.ALL;
     }
 
     @Override
@@ -405,7 +426,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, SOCKET_TIMEOUT,
             MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, SECURE,
             DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
-            UNAVAILABLE_POSITION_RECOVERY, SNAPSHOT_QUERY_TIME_LIMIT, MAX_RETRIEVAL_TIMEOUT, BLOCKING_SNAPSHOT_PAUSE_TIMEOUT);
+            UNAVAILABLE_POSITION_RECOVERY, SNAPSHOT_QUERY_TIME_LIMIT, MAX_RETRIEVAL_TIMEOUT, BLOCKING_SNAPSHOT_PAUSE_TIMEOUT,
+            ERRORS_TOLERANCE);
 
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
@@ -585,6 +607,49 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                 mode = parse(defaultValue);
             }
             return mode;
+        }
+    }
+
+    /**
+     * How much of the include list the connector insists on being able to capture before it starts. The
+     * default is strict: a configured table that silently never streams is worse than a visible failure.
+     */
+    public enum ErrorsTolerance implements EnumeratedValue {
+
+        NONE("none"),
+
+        ALL("all");
+
+        private final String value;
+
+        ErrorsTolerance(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static ErrorsTolerance parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (final ErrorsTolerance option : ErrorsTolerance.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        public static ErrorsTolerance parse(String value, String defaultValue) {
+            ErrorsTolerance tolerance = parse(value);
+            if (tolerance == null && defaultValue != null) {
+                tolerance = parse(defaultValue);
+            }
+            return tolerance;
         }
     }
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -15,6 +15,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.bean.StandardBeanNames;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -138,7 +139,13 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         }
 
         final List<FileFilter> shortIncludes = jdbcConnection.shortIncludes(schema.getSchemaName(),
-                configuredIncludes);
+                configuredIncludes, connectorConfig.skipUncapturableTables());
+        // No filters means "no include list", i.e. read the whole library's journal - which every configured
+        // table having been dropped must not silently turn into.
+        if (!Strings.isNullOrBlank(configuredIncludes) && shortIncludes.isEmpty()) {
+            throw new DebeziumException("none of the included tables exists, there is nothing to capture. Tables "
+                    + "requested: " + configuredIncludes);
+        }
 
         final long cacheWait = JournalInfoRetrieval.getJournalCacheDurationInMilliseconds(jdbcConnection);
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -56,6 +56,17 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
     private static final String GET_ALL_SYSTEM_TABLE_NAME = "select trim(system_table_name), trim(table_name) from qsys2.systables where system_table_schema=?";
 
     private static final String GET_TABLE_NAME = "select trim(table_name) from qsys2.systables where system_table_schema=? AND system_table_name=?";
+    /**
+     * Deliberately the loosest of the catalog lookups here, because a miss drops the table: the include list
+     * may name a table by its long or its system name, in any case (the journal RPC calls upper-case it
+     * anyway), and {@code SYSTEM_TABLE_NAME} comes back delimited - {@code "Vue10002"} - when it is not an
+     * ordinary identifier.
+     */
+    private static final String GET_TABLE_TYPE = """
+            select trim(table_type) from qsys2.systables
+            where upper(system_table_schema)=upper(?)
+            AND (upper(table_name)=upper(?) OR upper(replace(system_table_name, '"', ''))=upper(?))
+            """;
     private static final String GET_INDEXES = """
             SELECT c.column_name FROM qsys.QADBKATR k
                   INNER JOIN qsys2.SYSCOLUMNS c on c.table_schema=k.dbklib and c.system_table_name=k.dbkfil AND c.system_column_name=k.DBKFLD
@@ -113,7 +124,17 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         return this.connectionString(URL_PATTERN);
     }
 
-    public List<FileFilter> shortIncludes(String schema, String includes) {
+    /**
+     * Translate {@code table.include.list} into the journal's raw schema.table filters.
+     *
+     * <p>An entry that does not exist is dropped whatever {@code errors.tolerance} says, because Debezium
+     * ignores include-list entries with no matching table everywhere else; the journal path must not be the
+     * one component that refuses to start over it.</p>
+     *
+     * @param skipUncapturable when true ({@code errors.tolerance=all}) an SQL view is dropped too; when
+     *        false it is passed through and fails later, when its journal is resolved
+     */
+    public List<FileFilter> shortIncludes(String schema, String includes, boolean skipUncapturable) {
         if (includes == null || includes.isBlank()) {
             return Collections.<FileFilter> emptyList();
         }
@@ -141,9 +162,59 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
 
             final String tableSchema = schemaName;
             // AS400 does not handle double-quote escaping, so remove them before building FileFilter object
-            getSystemName(tableSchema, tableName.replaceAll("\"", "")).map(x -> r.add(new FileFilter(tableSchema, x)));
+            final String bareTableName = tableName.replaceAll("\"", "");
+            final IncludedObject included = classify(tableSchema, bareTableName);
+            if (included == IncludedObject.MISSING) {
+                log.error("dropping {}.{} from the journal filters, no such table - nothing will be captured for it",
+                        tableSchema, bareTableName);
+                continue;
+            }
+            if (included == IncludedObject.VIEW && skipUncapturable) {
+                log.error("errors.tolerance=all: dropping SQL view {}.{} from the journal filters, a view has no "
+                        + "journal of its own - nothing will be captured for it", tableSchema, bareTableName);
+                continue;
+            }
+            getSystemName(tableSchema, bareTableName).map(x -> r.add(new FileFilter(tableSchema, x)));
         }
         return r;
+    }
+
+    /** What the SQL catalog says about an entry of {@code table.include.list}. */
+    private enum IncludedObject {
+        CAPTURABLE,
+        VIEW,
+        MISSING
+    }
+
+    /**
+     * Classify an included table from the SQL catalog. A failure of the lookup itself counts as
+     * {@link IncludedObject#CAPTURABLE}, so a catalog hiccup cannot drop a table that is perfectly fine.
+     */
+    private IncludedObject classify(String schemaName, String tableName) {
+        final String tableType;
+        try {
+            tableType = getTableType(schemaName, tableName);
+        }
+        catch (final SQLException e) {
+            log.error("failed to look up the type of {}.{}, keeping it in the journal filters", schemaName, tableName, e);
+            return IncludedObject.CAPTURABLE;
+        }
+        if (tableType == null) {
+            return IncludedObject.MISSING;
+        }
+        return "V".equals(tableType) ? IncludedObject.VIEW : IncludedObject.CAPTURABLE;
+    }
+
+    /** The {@code TABLE_TYPE} of a table named by its long or system name, null when there is no such object. */
+    String getTableType(String schemaName, String tableName) throws SQLException {
+        return prepareQueryAndMap(GET_TABLE_TYPE,
+                call -> {
+                    call.setString(1, schemaName);
+                    call.setString(2, tableName);
+                    call.setString(3, tableName);
+                },
+                singleResultMapper(rs -> rs.getString(1).trim(), (String) null,
+                        String.format("no entry in qsys2.systables for %s.%s", schemaName, tableName)));
     }
 
     public String getRealDatabaseName() {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -28,6 +28,7 @@ import io.debezium.ibmi.db2.journal.retrieve.Connect;
 import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
 import io.debezium.ibmi.db2.journal.retrieve.JournalInfo;
 import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval;
+import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval.ResolvedJournal;
 import io.debezium.ibmi.db2.journal.retrieve.JournalPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
@@ -69,7 +70,9 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
         this.textFactory = createTextFactory();
         this.journalInfoRetrieval = new JournalInfoRetrieval(textFactory, cacheWait, config.cacheAdditionalDelay(), config.getPollInterval().toMillis());
         try {
-            journalInfo = journalInfoRetrieval.getJournal(connection(), config.getSchema(), includes);
+            final ResolvedJournal resolved = journalInfoRetrieval.resolveJournal(connection(), config.getSchema(),
+                    includes, config.skipUncapturableTables());
+            journalInfo = resolved.journalInfo();
 
             boolean transactionMgt = config.isTransactionMgmtEnabled();
 
@@ -79,7 +82,7 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
                     .withJournalInfo(journalInfo)
                     .withMaxServerSideEntries(config.getMaxServerSideEntries())
                     .withServerFiltering(!transactionMgt)
-                    .withIncludeFiles(includes).withDumpFolder(config.diagnosticsFolder())
+                    .withIncludeFiles(resolved.includes()).withDumpFolder(config.diagnosticsFolder())
                     .build();
             retrieveJournal = new RetrieveJournal(rconfig, journalInfoRetrieval);
         }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -153,7 +153,6 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                                 break;
                             case NotCalled:
                                 metronome.pause();
-                                dispatcher.dispatchHeartbeatEventAlsoToIncrementalSnapshot(partition, offsetContext);
                                 break;
                             default:
                                 metronome.pause();

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigErrorsToleranceTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigErrorsToleranceTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+
+class As400ConnectorConfigErrorsToleranceTest {
+
+    private static As400ConnectorConfig config(String tolerance) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX");
+        if (tolerance != null) {
+            builder.with(As400ConnectorConfig.ERRORS_TOLERANCE, tolerance);
+        }
+        return new As400ConnectorConfig(builder.build());
+    }
+
+    @Test
+    void onlyAllSkipsUncapturableTables() {
+        assertThat(config("all").skipUncapturableTables()).isTrue();
+        assertThat(config("ALL").skipUncapturableTables()).isTrue();
+        assertThat(config("none").skipUncapturableTables()).isFalse();
+    }
+
+    @Test
+    void defaultAndInvalidValuesAreStrict() {
+        assertThat(config(null).skipUncapturableTables()).isFalse();
+        assertThat(config("bogus").skipUncapturableTables()).isFalse();
+    }
+}

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionShortIncludesTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionShortIncludesTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
+
+/**
+ * Covers the handling of {@code table.include.list} entries the journal cannot capture, both detectable
+ * from the SQL catalog without an RPC call: a table that does not exist is always dropped (Debezium
+ * ignores include-list entries with no matching table), an SQL view only with {@code errors.tolerance=all}.
+ *
+ * <p>Exercised through a {@code CALLS_REAL_METHODS} mock — {@link As400JdbcConnection}'s constructor
+ * eagerly resolves the real database name and would otherwise require a live AS400.</p>
+ */
+public class As400JdbcConnectionShortIncludesTest {
+
+    private final As400JdbcConnection connection = mock(As400JdbcConnection.class, CALLS_REAL_METHODS);
+
+    @Test
+    void tolerant_mode_skips_missing_tables_and_views() throws Exception {
+        // Given a library holding a table, a dropped table and an SQL view
+        doReturn("T").when(connection).getTableType("LIB1", "T1");
+        doReturn(null).when(connection).getTableType("LIB1", "GONE");
+        doReturn("V").when(connection).getTableType("LIB1", "VUE1");
+        doReturn(Optional.of("T1")).when(connection).getSystemName("LIB1", "T1");
+
+        // When translating the include list with errors.tolerance=all
+        List<FileFilter> includes = connection.shortIncludes("LIB1", "LIB1.T1,LIB1.GONE,LIB1.VUE1", true);
+
+        // Then only the capturable table reaches the journal filters
+        assertThat(includes).containsExactly(new FileFilter("LIB1", "T1"));
+    }
+
+    @Test
+    void tolerant_mode_keeps_the_table_when_the_catalog_lookup_fails() throws Exception {
+        // Given a catalog lookup that blows up rather than answering
+        doThrow(new SQLException("catalog unavailable")).when(connection).getTableType("LIB1", "T1");
+        doReturn(Optional.of("T1")).when(connection).getSystemName("LIB1", "T1");
+
+        // When translating the include list with errors.tolerance=all
+        List<FileFilter> includes = connection.shortIncludes("LIB1", "LIB1.T1", true);
+
+        // Then the table is kept - a catalog hiccup must not silently drop a capturable table
+        assertThat(includes).containsExactly(new FileFilter("LIB1", "T1"));
+    }
+
+    @Test
+    void default_mode_still_drops_a_missing_table_but_keeps_a_view() throws Exception {
+        // Given a library holding a table, a dropped table and an SQL view, with errors.tolerance left at none
+        doReturn("T").when(connection).getTableType("LIB1", "T1");
+        doReturn(null).when(connection).getTableType("LIB1", "GONE");
+        doReturn("V").when(connection).getTableType("LIB1", "VUE1");
+        doReturn(Optional.of("T1")).when(connection).getSystemName("LIB1", "T1");
+        doReturn(Optional.of("VUE10002")).when(connection).getSystemName("LIB1", "VUE1");
+
+        // When translating the include list
+        List<FileFilter> includes = connection.shortIncludes("LIB1", "LIB1.T1,LIB1.GONE,LIB1.VUE1", false);
+
+        // Then the table that does not exist is dropped as Debezium drops it everywhere else, while the view
+        // is kept and fails later, loudly, when its journal is resolved
+        assertThat(includes).containsExactly(new FileFilter("LIB1", "T1"), new FileFilter("LIB1", "VUE10002"));
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -191,19 +191,42 @@ public class JournalInfoRetrieval {
      *         than one journal
      */
     public JournalInfo getJournal(AS400 as400, String schema, List<FileFilter> includes) throws IllegalStateException {
+        return resolveJournal(as400, schema, includes, false).journalInfo();
+    }
+
+    /** The journal shared by the included tables, and the filters that resolved to it. */
+    public record ResolvedJournal(JournalInfo journalInfo, List<FileFilter> includes) {
+    }
+
+    /**
+     * Resolve the journal shared by all included tables, as {@link #getJournal(AS400, String, List)}, but
+     * optionally tolerating tables that have no journal.
+     *
+     * @param skipUncapturable when true ({@code errors.tolerance=all}) a table whose journal cannot be
+     *        retrieved is logged at ERROR level and left out of the returned filters instead of failing;
+     *        the multi-journal case and an include list where nothing resolves stay fatal either way
+     */
+    public ResolvedJournal resolveJournal(AS400 as400, String schema, List<FileFilter> includes, boolean skipUncapturable)
+            throws IllegalStateException {
         if (includes.isEmpty()) {
-            return getJournal(as400, schema);
+            return new ResolvedJournal(getJournal(as400, schema), includes);
         }
         final Set<JournalInfo> jis = new HashSet<>();
         final Set<String> libraries = new TreeSet<>();
-        try {
-            for (final FileFilter f : includes) {
-                libraries.add(f.schema());
+        final List<FileFilter> journaled = new ArrayList<>();
+        for (final FileFilter f : includes) {
+            libraries.add(f.schema());
+            try {
                 jis.add(getJournal(as400, f.schema(), f.table()));
+                journaled.add(f);
             }
-        }
-        catch (final Exception e) {
-            throw new IllegalStateException("unable to retrieve journal details", e);
+            catch (final Exception e) {
+                if (!skipUncapturable) {
+                    throw new IllegalStateException("unable to retrieve journal details", e);
+                }
+                log.error("errors.tolerance=all: dropping {}.{} from the journal filters, it has no journal - "
+                        + "nothing will be captured for it", f.schema(), f.table(), e);
+            }
         }
         if (jis.size() > 1) {
             throw new IllegalStateException(String.format(
@@ -212,7 +235,12 @@ public class JournalInfoRetrieval {
                             + "distinct journals found: %s",
                     libraries, jis));
         }
-        return jis.iterator().next();
+        if (jis.isEmpty()) {
+            throw new IllegalStateException(String.format(
+                    "none of the included tables has a journal, there is nothing to capture. Libraries requested: %s",
+                    libraries));
+        }
+        return new ResolvedJournal(jis.iterator().next(), journaled);
     }
 
     public JournalInfo getJournal(AS400 as400, String schema, String table) throws Exception {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -222,7 +222,10 @@ public class JournalInfoRetrieval {
             }
             catch (final Exception e) {
                 if (!skipUncapturable) {
-                    throw new IllegalStateException("unable to retrieve journal details", e);
+                    throw new IllegalStateException(String.format(
+                            "unable to retrieve journal details for %s.%s - set errors.tolerance=all to skip it and "
+                                    + "capture the remaining tables",
+                            f.schema(), f.table()), e);
                 }
                 log.error("errors.tolerance=all: dropping {}.{} from the journal filters, it has no journal - "
                         + "nothing will be captured for it", f.schema(), f.table(), e);

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
@@ -68,8 +68,9 @@ class JournalInfoRetrievalGetJournalTest {
                 () -> retrieval.resolveJournal(as400, "LIB1",
                         List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB1", "VIEW1")), false));
 
-        // Then startup fails rather than silently never streaming that table
+        // Then startup fails rather than silently never streaming that table, naming the offending table
         assertTrue(ex.getMessage().contains("unable to retrieve journal details"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("LIB1.VIEW1"), ex.getMessage());
     }
 
     @Test

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
 import java.util.List;
@@ -26,6 +27,10 @@ import io.debezium.ibmi.db2.journal.data.types.As400TextFactory;
  * Unit tests for {@link JournalInfoRetrieval#getJournal(AS400, String, List)} covering the
  * multi-library support: tables spread across libraries are allowed as long as they share a single
  * journal, and the multi-journal case is rejected with an explicit message.
+ *
+ * <p>Also covers {@link JournalInfoRetrieval#resolveJournal(AS400, String, List, boolean)}, which backs
+ * {@code errors.tolerance}: a table with no journal fails startup by default and is dropped from the
+ * journal filters when tolerated.</p>
  */
 @ExtendWith(MockitoExtension.class)
 class JournalInfoRetrievalGetJournalTest {
@@ -49,6 +54,52 @@ class JournalInfoRetrievalGetJournalTest {
 
         // Then the shared journal is returned without error
         assertEquals(journalA, result);
+    }
+
+    @Test
+    void unjournaledTableFailsWhenNotTolerant() throws Exception {
+        // Given one table that resolves and one whose journal cannot be retrieved
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(As400TextFactory.forCcsid(37), 0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doThrow(new IllegalStateException("Journal not found for LIB1.VIEW1")).when(retrieval).getJournal(as400, "LIB1", "VIEW1");
+
+        // When resolving with errors.tolerance=none
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> retrieval.resolveJournal(as400, "LIB1",
+                        List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB1", "VIEW1")), false));
+
+        // Then startup fails rather than silently never streaming that table
+        assertTrue(ex.getMessage().contains("unable to retrieve journal details"), ex.getMessage());
+    }
+
+    @Test
+    void unjournaledTableIsDroppedFromTheFiltersWhenTolerant() throws Exception {
+        // Given one table that resolves and one whose journal cannot be retrieved
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(As400TextFactory.forCcsid(37), 0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doThrow(new IllegalStateException("Journal not found for LIB1.VIEW1")).when(retrieval).getJournal(as400, "LIB1", "VIEW1");
+
+        // When resolving with errors.tolerance=all
+        final JournalInfoRetrieval.ResolvedJournal resolved = retrieval.resolveJournal(as400, "LIB1",
+                List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB1", "VIEW1")), true);
+
+        // Then the capturable table keeps streaming and the other is left out of the journal filters
+        assertEquals(journalA, resolved.journalInfo());
+        assertEquals(List.of(new FileFilter("LIB1", "T1")), resolved.includes());
+    }
+
+    @Test
+    void allTablesUnjournaledFailsEvenWhenTolerant() throws Exception {
+        // Given an include list where nothing can be captured
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(As400TextFactory.forCcsid(37), 0L, 0L, 0L));
+        doThrow(new IllegalStateException("Journal not found for LIB1.T1")).when(retrieval).getJournal(as400, "LIB1", "T1");
+
+        // When resolving with errors.tolerance=all
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> retrieval.resolveJournal(as400, "LIB1", List.of(new FileFilter("LIB1", "T1")), true));
+
+        // Then the connector still refuses to start with nothing to capture
+        assertTrue(ex.getMessage().contains("nothing to capture"), ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Debezium table.include.list will fail quietly on a missing table as it's a *filter*
- A VIEW will fail loudly if error.tolerance=none (default), skip if it's "all"
- A missing journal will fail loudly if error.tolerance=none (default), skip if it's "all"