### PR TITLE
Skips the member-less table only if error.tolerance=all 

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,6 +67,11 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
             select trim(table_type) from qsys2.systables
             where upper(system_table_schema)=upper(?)
             AND (upper(table_name)=upper(?) OR upper(replace(system_table_name, '"', ''))=upper(?))
+            """;
+    /** One row per member; both names returned, matching as loose as {@link #GET_TABLE_TYPE} because a miss can drop the table. */
+    private static final String TABLES_WITH_MEMBERS = """
+            select distinct upper(table_name), upper(replace(system_table_name, '"', ''))
+            from qsys2.syspartitionstat where upper(system_table_schema)=upper(?)
             """;
     private static final String GET_INDEXES = """
             SELECT c.column_name FROM qsys.QADBKATR k
@@ -215,6 +221,20 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                 },
                 singleResultMapper(rs -> rs.getString(1).trim(), (String) null,
                         String.format("no entry in qsys2.systables for %s.%s", schemaName, tableName)));
+    }
+
+    /** Upper-cased long and system names of every file in the schema that still has a member; a file without one fails any SQL access with {@code SQL0204}. */
+    public Set<String> tablesWithMembers(String schemaName) throws SQLException {
+        return prepareQueryAndMap(TABLES_WITH_MEMBERS,
+                call -> call.setString(1, schemaName),
+                rs -> {
+                    final Set<String> names = new HashSet<>();
+                    while (rs.next()) {
+                        names.add(rs.getString(1).trim());
+                        names.add(rs.getString(2).trim());
+                    }
+                    return names;
+                });
     }
 
     public String getRealDatabaseName() {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +168,37 @@ public class As400SnapshotChangeEventSource
         for (final String schema : connectorConfig.getCaptureSchemas()) {
             tables.addAll(jdbcConnection.readTableNames(databaseName, schema, null, new String[]{ "TABLE" }));
         }
+        if (connectorConfig.skipUncapturableTables()) {
+            dropMemberlessFiles(tables);
+        }
         return tables;
+    }
+
+    /**
+     * A memberless physical file fails any SQL access with {@code SQL0204} and would abort the snapshot of
+     * every other table; under {@code errors.tolerance=all} it is dropped instead.
+     */
+    private void dropMemberlessFiles(Set<TableId> tables) {
+        final Set<String> schemas = tables.stream().map(TableId::schema).collect(Collectors.toSet());
+        for (final String schema : schemas) {
+            final Set<String> withMembers;
+            try {
+                withMembers = jdbcConnection.tablesWithMembers(schema);
+            }
+            catch (final SQLException e) {
+                log.error("failed to list the tables of {} with members, keeping them all in the snapshot", schema, e);
+                continue;
+            }
+            final Iterator<TableId> iterator = tables.iterator();
+            while (iterator.hasNext()) {
+                final TableId tableId = iterator.next();
+                if (schema.equals(tableId.schema()) && !withMembers.contains(tableId.table().toUpperCase())) {
+                    log.error("errors.tolerance=all: dropping {} from the snapshot, the physical file has no member "
+                            + "- nothing will be captured for it", tableId);
+                    iterator.remove();
+                }
+            }
+        }
     }
 
     @Override
@@ -289,6 +320,22 @@ public class As400SnapshotChangeEventSource
         }
         String fullTableName = String.format("%s.%s", tableId.schema(), table);
         return snapshotterService.getSnapshotQuery().snapshotQuery(fullTableName, columns);
+    }
+
+    @Override
+    protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
+        try {
+            return super.rowCountForTableChunked(tableId);
+        }
+        catch (SQLException e) {
+            final String hint = switch (e.getErrorCode()) {
+                case -204 -> " (SQL0204: the physical file may have no member, or the table was dropped after discovery)";
+                case -551, -552 -> " (SQL0551/SQL0552: the connecting user profile is not authorized to the table)";
+                case -913 -> " (SQL0913: the object is locked - a save or reorganize may be running)";
+                default -> "";
+            };
+            throw new SQLException("Failed to count rows for table " + tableId + hint, e.getSQLState(), e.getErrorCode(), e);
+        }
     }
 
     @Override

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceMemberlessTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceMemberlessTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
+import io.debezium.util.Clock;
+
+/**
+ * A physical file with no member fails any SQL access with {@code SQL0204}; with
+ * {@code errors.tolerance=all} it is dropped from the snapshot, by default the failure names the table.
+ */
+public class As400SnapshotChangeEventSourceMemberlessTest {
+
+    private static final TableId T1 = new TableId(null, "LIB1", "T1");
+    private static final TableId EMPTY = new TableId(null, "LIB1", "NOMEMBER");
+
+    private final As400JdbcConnection connection = mock(As400JdbcConnection.class);
+
+    @SuppressWarnings("unchecked")
+    private As400SnapshotChangeEventSource source(String tolerance) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, "LIB1");
+        if (tolerance != null) {
+            builder.with(As400ConnectorConfig.ERRORS_TOLERANCE, tolerance);
+        }
+        final MainConnectionProvidingConnectionFactory<As400JdbcConnection> factory = mock(MainConnectionProvidingConnectionFactory.class);
+        when(factory.mainConnection()).thenReturn(connection);
+        return new As400SnapshotChangeEventSource(new As400ConnectorConfig(builder.build()),
+                mock(As400RpcConnection.class), factory, mock(As400DatabaseSchema.class),
+                mock(EventDispatcher.class), Clock.SYSTEM, mock(SnapshotProgressListener.class),
+                mock(NotificationService.class), mock(SnapshotterService.class));
+    }
+
+    private void discovered(TableId... tables) throws SQLException {
+        doReturn("RDB").when(connection).getRealDatabaseName();
+        doReturn(new LinkedHashSet<>(List.of(tables))).when(connection).readTableNames(any(), any(), any(), any());
+    }
+
+    @Test
+    void tolerant_mode_drops_a_memberless_file_from_the_snapshot() throws Exception {
+        discovered(T1, EMPTY);
+        doReturn(Set.of("T1")).when(connection).tablesWithMembers("LIB1");
+
+        assertThat(source("all").getAllTableIds(null)).containsExactly(T1);
+    }
+
+    @Test
+    void default_mode_keeps_a_memberless_file_and_fails_loud_later() throws Exception {
+        discovered(T1, EMPTY);
+
+        assertThat(source(null).getAllTableIds(null)).containsExactly(T1, EMPTY);
+    }
+
+    @Test
+    void row_count_failure_names_the_table() throws Exception {
+        doThrow(new SQLException("[SQL0551] Not authorized to object.", "42501", -551))
+                .when(connection).queryAndMap(any(String.class), any());
+
+        assertThatThrownBy(() -> source(null).rowCountForTableChunked(T1))
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("LIB1.T1")
+                .hasMessageContaining("not authorized");
+    }
+}


### PR DESCRIPTION
In any case surface a better error message with the table name