### PR TITLE
Fix SLF4J placeholder mismatches dropping diagnostic values

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -236,8 +236,11 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
             streamingMetrics.setJournalOffset(currentReceiver.getOffset());
             streamingMetrics.setJournalBehind(behind);
             streamingMetrics.setLastProcessedMs(position.getTimeOfLastProcessed().toEpochMilli());
-            log.info("Current position diagnostics last call {}, header {}, behind {}, currentReceiver", state, retrieveJournal.getFirstHeader(), behind,
-                    currentReceiver);
+            log.info(
+                    "Current position diagnostics last call {}, parked on receiver {} at offset {}, journal attached to receiver {} at offset {}, behind {}, header {}",
+                    state, position.getReceiver(), position.getOffset(),
+                    currentReceiver.getReceiver(), currentReceiver.getOffset(), behind,
+                    retrieveJournal.getFirstHeader());
         }
     }
 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DetailedJournalReceiverCache.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/DetailedJournalReceiverCache.java
@@ -38,7 +38,7 @@ public class DetailedJournalReceiverCache {
         String key = toKey(receiverInfo);
         DetailedJournalReceiver dr = cached.get(key);
         if (dr.info() == null || dr.info().status() == null) {
-            log.warn("null in receiver info", dr);
+            log.warn("null in receiver info {}", dr);
         }
         if (receiverInfo.status() != null && dr.info() != null && !receiverInfo.status().equals(dr.info().status())) {
             dr = dr.withStatus(receiverInfo.status());


### PR DESCRIPTION
`logOffsets` built the periodic *"Current position diagnostics"* line with three `{}` placeholders but passed four arguments, so SLF4J silently discarded `currentReceiver` — the receiver the journal is actually attached to on the server, and the value the message exists to surface. Rather than only adding the missing placeholder, this prints the parked-on and attached receivers side by side with their offsets and moves the long `FirstHeader` dump to the end, so the comparison that distinguishes a genuinely idle journal from a stale idea of the current receiver is readable directly from the log.

A sweep of every `.java` file for placeholder/argument mismatches turned up one more real instance, unreported: `DetailedJournalReceiverCache` passed a `DetailedJournalReceiver` to a `warn` call with no placeholder, so the warning fired without saying which receiver was null. The three remaining candidates are legitimate — each passes a trailing `new ...Exception(...)`, which SLF4J correctly renders as a stack trace.

Not included: the build-time detector suggested in the issue (`findbugs-slf4j` / ErrorProne). That needs a SpotBugs execution in the parent POM and would likely surface unrelated findings on first run, so it belongs in its own change — worth noting that checkstyle was never the safety net here anyway, since `pom.xml:173-181` binds `check-style` to phase `none`.

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)