### PR TITLE
Give the streaming retry path its own backoff (#59)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -46,6 +46,8 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
 
     private static final int TRANSACTION_MAP_WARN_SIZE = 50_000;
     private static final int MAX_RETRIES = 20;
+    /** Retry backoff grows from {@code poll.interval.ms} up to this multiple of it, then stays there. */
+    private static final long MAX_RETRY_BACKOFF_MULTIPLIER = 8;
 
     private static final Logger log = LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
 
@@ -169,7 +171,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         // streaming: data is already lost, so apply the configured recovery strategy rather
                         // than silently skipping on
                         applyUnavailablePositionRecovery(offsetContext, e);
-                        retries = pauseBeforeRetry(retries, offsetContext, e, metronome);
+                        retries = pauseBeforeRetry(retries, offsetContext, e);
                     }
                     catch (final FatalException e) {
                         throw new DebeziumException("Unable to process offset " + offsetContext.getPosition(), e);
@@ -178,7 +180,7 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         if (context.isRunning()) {
                             log.error("Interrupted processing offset {} retry {}", offsetContext.getPosition(), retries);
                             closeAndReconnect();
-                            retries = pauseBeforeRetry(retries, offsetContext, e, metronome);
+                            retries = pauseBeforeRetry(retries, offsetContext, e);
                         }
                     }
                     catch (IOException | SQLNonTransientConnectionException e) { // SQLNonTransientConnectionException
@@ -187,12 +189,12 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         log.error("Connection failed offset {} retry {}", offsetContext.getPosition(), retries, e);
                         closeAndReconnect();
 
-                        retries = pauseBeforeRetry(retries, offsetContext, e, metronome);
+                        retries = pauseBeforeRetry(retries, offsetContext, e);
                     }
                     catch (final Exception e) {
                         log.error("Failed to process offset {} retry {}", offsetContext.getPosition(), retries, e);
 
-                        retries = pauseBeforeRetry(retries, offsetContext, e, metronome);
+                        retries = pauseBeforeRetry(retries, offsetContext, e);
                     }
                 }
                 catch (final InterruptedException e) { // handle InterruptedException during the exception handling
@@ -240,22 +242,46 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     /**
-     * Waits out the poll interval before the next attempt, giving up once the same failure has been retried
-     * {@link #MAX_RETRIES} times so a permanently broken stream fails the connector instead of retrying
-     * forever. A lost connection is retriable, so failing here restarts the connector, see
-     * {@link As400ErrorHandler}.
+     * Waits out an exponentially growing backoff before the next attempt, giving up once the same failure
+     * has been retried {@link #MAX_RETRIES} times so a permanently broken stream fails the connector
+     * instead of retrying forever. A lost connection is retriable, so failing here restarts the connector,
+     * see {@link As400ErrorHandler}.
+     * <p>
+     * The wait is deliberately not taken from the streaming loop's {@link Metronome}. That one advances its
+     * tick by exactly one period per {@code pause()} call rather than by the wall clock, and the healthy
+     * path never calls it - {@code Success} and {@code MoreDataAvailable} both fall straight through - so by
+     * the time a failure burst starts its tick is behind by roughly the whole time spent streaming and every
+     * {@code pause()} returns immediately. Sharing it inverted the intent: the busier the connector, the
+     * less backoff it got, and 20 attempts could be spent in under 3 seconds.
      *
      * @return the number of retries attempted so far
      */
-    private static int pauseBeforeRetry(int retries, As400OffsetContext offsetContext, Exception e, Metronome metronome)
+    private int pauseBeforeRetry(int retries, As400OffsetContext offsetContext, Exception e)
             throws InterruptedException {
         final int attempted = retries + 1;
         if (attempted >= MAX_RETRIES) {
             throw new DebeziumException(
                     String.format("Failed to process offset %s after %d retries", offsetContext.getPosition(), attempted), e);
         }
-        metronome.pause();
+        final Duration backoff = retryBackoff(retries);
+        log.info("Retrying offset {} in {}ms, attempt {}/{}", offsetContext.getPosition(), backoff.toMillis(), attempted,
+                MAX_RETRIES);
+        // a Metronome of its own, created here, so this first and only pause() really waits the whole backoff
+        Metronome.sleeper(backoff, clock).pause();
         return attempted;
+    }
+
+    /**
+     * {@code pollInterval * 2^retries}, capped at {@link #MAX_RETRY_BACKOFF_MULTIPLIER} times the poll
+     * interval so the wait stays proportional to how often the connector was asked to poll. The whole
+     * {@link #MAX_RETRIES} budget spans 135 poll intervals: about 68s at the 500ms default, about 4.5
+     * minutes at {@code poll.interval.ms=2000} - rather than the 2.7 seconds it took while the streaming
+     * metronome was shared.
+     */
+    Duration retryBackoff(int retries) {
+        // 1L << 30 already dwarfs the cap; clamping the shift keeps it out of overflow territory
+        final long multiplier = Math.min(1L << Math.min(retries, 30), MAX_RETRY_BACKOFF_MULTIPLIER);
+        return pollInterval.multipliedBy(multiplier);
     }
 
     public void closeAndReconnect() {

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRetryBackoffTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRetryBackoffTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
+import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+/**
+ * Verifies that the streaming loop's retry path actually waits between attempts.
+ * <p>
+ * The bug this covers was invisible to a count-based assertion: the retries were all made, they were
+ * just made instantly, because the error path borrowed the streaming loop's {@link io.debezium.util.Metronome}
+ * and that one advances its tick once per {@code pause()} call rather than by the wall clock. A connector
+ * that had been streaming with data never called {@code pause()}, so its tick was behind by the whole
+ * streaming time and every retry pause returned immediately - the whole retry budget went in milliseconds.
+ * These tests therefore assert <em>elapsed time</em>, not attempt counts.
+ */
+class As400StreamingChangeEventSourceRetryBackoffTest {
+
+    private static final int WATCHDOG_TIMEOUT_MS = 60_000;
+    /** Small enough to keep the tests quick, large enough that the assertions aren't scheduler noise. */
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(5);
+    /**
+     * What {@link #POLL_INTERVAL} the 19 pauses of an exhausted retry budget add up to:
+     * 1 + 2 + 4 (attempts 1-3) + 8 x 16 (attempts 4-19, capped).
+     */
+    private static final long TOTAL_BACKOFF_IN_POLL_INTERVALS = 135;
+
+    private final As400ConnectorConfig config = mock(As400ConnectorConfig.class);
+    private final As400RpcConnection dataConnection = mock(As400RpcConnection.class);
+    private final As400JdbcConnection jdbcConnection = mock(As400JdbcConnection.class);
+    private final As400OffsetContext offsetContext = mock(As400OffsetContext.class);
+
+    /** Runs the streaming loop for a bounded number of iterations, never pausing for a snapshot. */
+    private static final class BoundedContext implements ChangeEventSourceContext {
+        private final AtomicInteger iterations = new AtomicInteger();
+        private final int maxIterations;
+
+        BoundedContext(int maxIterations) {
+            this.maxIterations = maxIterations;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return iterations.getAndIncrement() < maxIterations;
+        }
+
+        @Override
+        public boolean isPaused() {
+            return false;
+        }
+
+        @Override
+        public void streamingPaused() {
+        }
+
+        @Override
+        public void waitSnapshotCompletion() {
+        }
+
+        @Override
+        public void resumeStreaming() {
+        }
+
+        @Override
+        public void waitStreamingPaused() {
+        }
+    }
+
+    private As400StreamingChangeEventSource source() {
+        when(config.getPollInterval()).thenReturn(POLL_INTERVAL);
+        when(config.getMaxRetrievalTimeout()).thenReturn(WATCHDOG_TIMEOUT_MS);
+        when(config.getSnapshotMode()).thenReturn(As400ConnectorConfig.SnapshotMode.WHEN_NEEDED);
+        when(jdbcConnection.getRealDatabaseName()).thenReturn("DB");
+        when(offsetContext.getPosition()).thenReturn(new JournalProcessedPosition(
+                BigInteger.valueOf(82), new JournalReceiver("RECV008", "RCV_LIB"), Instant.ofEpochSecond(123_456L), true));
+
+        @SuppressWarnings("unchecked")
+        final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
+        return new As400StreamingChangeEventSource(config, dataConnection, jdbcConnection, dispatcher,
+                mock(ErrorHandler.class), Clock.SYSTEM, mock(As400DatabaseSchema.class));
+    }
+
+    @Test
+    void backoffGrowsWithEachRetryThenLevelsOffAtTheCap() {
+        final As400StreamingChangeEventSource source = source();
+
+        assertThat(source.retryBackoff(0)).isEqualTo(POLL_INTERVAL);
+        assertThat(source.retryBackoff(1)).isEqualTo(POLL_INTERVAL.multipliedBy(2));
+        assertThat(source.retryBackoff(2)).isEqualTo(POLL_INTERVAL.multipliedBy(4));
+        assertThat(source.retryBackoff(3)).isEqualTo(POLL_INTERVAL.multipliedBy(8));
+        // capped from here on, including at the very edge of the retry budget
+        assertThat(source.retryBackoff(4)).isEqualTo(POLL_INTERVAL.multipliedBy(8));
+        assertThat(source.retryBackoff(19)).isEqualTo(POLL_INTERVAL.multipliedBy(8));
+        // and no overflow for a shift that would wrap a long
+        assertThat(source.retryBackoff(Integer.MAX_VALUE)).isEqualTo(POLL_INTERVAL.multipliedBy(8));
+    }
+
+    /**
+     * The regression: a connector that streamed with data for a while, then hit a failure burst, must still
+     * spread its retries. Before the fix the first successful iteration alone was enough to put the shared
+     * metronome's tick far enough behind that all 20 attempts were consumed with no waiting at all.
+     */
+    @Test
+    void retriesStillWaitAfterTheLoopHasBeenStreamingWithData() throws Exception {
+        final As400StreamingChangeEventSource source = source();
+        // timed from the first failure, not from the start of the loop, so the streaming phase's own
+        // duration is not what the assertion is measuring
+        final AtomicLong firstFailureAt = new AtomicLong();
+        when(dataConnection.getJournalEntries(any(), any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    // one healthy iteration that takes real time, i.e. what a connector catching up does;
+                    // this is what used to buy the error path 60 poll intervals of instant pauses
+                    Thread.sleep(POLL_INTERVAL.multipliedBy(60).toMillis());
+                    return RetrievalState.Success;
+                })
+                .thenAnswer(invocation -> {
+                    firstFailureAt.compareAndSet(0, System.nanoTime());
+                    throw new IOException("journal RPC call failed");
+                });
+
+        assertThatThrownBy(() -> source.execute(new BoundedContext(1000), new As400Partition("server"), offsetContext))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("after 20 retries");
+
+        final Duration spentRetrying = Duration.ofNanos(System.nanoTime() - firstFailureAt.get());
+        // the 19 pauses of an exhausted budget, halved to leave room for a coarse scheduler. Before the fix
+        // this burst took about 33ms, i.e. an order of magnitude under the threshold, whatever the margin
+        assertThat(spentRetrying).isGreaterThan(POLL_INTERVAL.multipliedBy(TOTAL_BACKOFF_IN_POLL_INTERVALS / 2));
+    }
+
+    /**
+     * The idle path keeps the loop's own metronome, so a connector that is called but finds nothing still
+     * polls at its configured interval rather than spinning.
+     */
+    @Test
+    void anIdleLoopStillPacesItselfAtThePollInterval() throws Exception {
+        final As400StreamingChangeEventSource source = source();
+        when(dataConnection.getJournalEntries(any(), any(), any(), any())).thenReturn(RetrievalState.NotCalled);
+
+        final long startedAt = System.nanoTime();
+        source.execute(new BoundedContext(20), new As400Partition("server"), offsetContext);
+        final Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+        assertThat(elapsed).isGreaterThan(POLL_INTERVAL.multipliedBy(20 / 2));
+    }
+}


### PR DESCRIPTION
Closes #59.

## What was wrong

The streaming loop's error path borrowed the loop's own `Metronome`, and `Metronome.sleeper` advances its tick by exactly one period **per `pause()` call**, not by the wall clock:

```java
public void pause() throws InterruptedException {
    for (;;) {
        final long now = timeSystem.currentTimeInMillis();
        if (next <= now) { break; }          // already late -> return immediately
        Thread.sleep(next - now);
    }
    next = next + periodInMillis;            // +1 period per call, regardless of elapsed time
}
```

The healthy path never calls it — `Success` and `MoreDataAvailable` both `break` — so by the time a failure burst starts, the tick is behind by roughly the whole time spent streaming, and `pause()` returns instantly for as many calls as it takes to catch up. With `MAX_RETRIES = 20` and a 2s period, a drift over ~40s consumed every retry with zero waiting.

The intent came out inverted: **the busier the connector, the less backoff it got.** An idle connector paused every iteration, kept its tick current, and did get the intended spread; a connector actually catching up got none. Observed live as 20 retries in 2711ms (~143ms apart, i.e. the RPC round-trip), turning a transient journal RPC failure into a container restart — the worst-hit connector of that deployment took 144 restarts in 6 days and produced ~19k events over the period.

## What this does

`pauseBeforeRetry` sleeps on a `Metronome` of its own, created per call so the first and only `pause()` waits the full period, and the period grows exponentially from `pollInterval` to 8x it:

| attempt | 1 | 2 | 3 | 4+ |
|---|---|---|---|---|
| wait | 1x poll | 2x | 4x | 8x (capped) |

The whole retry budget spans 135 poll intervals instead of collapsing to nothing: **~68s at the 500ms default, ~4.5 min at the `poll.interval.ms=2000`** the affected deployment used. Keeping the cap a multiple of the poll interval rather than a fixed duration is deliberate — the wait stays proportional to how often the connector was asked to poll, which is the property the issue says was promised and not delivered.

The idle path (`NotCalled` / `default`) keeps the loop's metronome. That is the use it was written for, and a test pins it so the fix does not turn an idle loop into a spin.

## On the test

This is the part worth reviewing. The bug was **invisible to a count-based assertion** — every retry was made, just instantly — so the test asserts elapsed time across a burst that follows a streaming iteration, which is what creates the drift in the first place. It measures from the first failure rather than from loop start, so the streaming phase is not part of what is asserted.

Verified against the pre-fix source: that burst takes **~32ms against a 335ms threshold**, an order of magnitude of margin. A first version of the test timed the whole loop and only failed by 2ms (333 vs 335) — that would have been a flaky regression test, hence the narrower measurement.

## Deliberately left out

The issue's point 2 (an optional wall-clock retry budget) is not implemented. The backoff already makes "20 attempts" mean minutes rather than seconds, so a second bound would add a knob with no failure mode left to catch. Happy to add it if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
