### PR TITLE
Scope the system-name prefetch to the captured tables (#50)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -13,6 +13,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,7 +55,18 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
 
     private static final String GET_DATABASE_NAME = "values ( CURRENT_SERVER )";
     private static final String GET_SYSTEM_TABLE_NAME = "select trim(system_table_name) from qsys2.systables where system_table_schema=? AND table_name=?";
-    private static final String GET_ALL_SYSTEM_TABLE_NAME = "select trim(system_table_name), trim(table_name) from qsys2.systables where system_table_schema=?";
+    /**
+     * Matches on either name, as loosely as {@link #GET_TABLE_TYPE}: the captured set may name a table by
+     * its long or its system name, and {@code SYSTEM_TABLE_NAME} comes back delimited when it is not an
+     * ordinary identifier. The placeholder list is bound twice, once per column.
+     */
+    private static final String GET_SYSTEM_TABLE_NAMES = """
+            select trim(system_table_name), trim(table_name) from qsys2.systables
+            where system_table_schema=?
+            and (upper(table_name) in (%1$s) or upper(replace(system_table_name, '"', '')) in (%1$s))
+            """;
+    /** Table names per {@code IN} list, two bind parameters each, so a whole-library include list stays inside any statement limit. */
+    private static final int SYSTEM_NAME_BATCH_SIZE = 500;
 
     private static final String GET_TABLE_NAME = "select trim(table_name) from qsys2.systables where system_table_schema=? AND system_table_name=?";
     /**
@@ -328,10 +340,38 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         return columnsByTable;
     }
 
-    public void getAllSystemNames(String schemaName) throws SQLException, InterruptedException {
-        prepareQueryWithBlockingConsumer(GET_ALL_SYSTEM_TABLE_NAME, call -> {
-            call.setString(1, schemaName);
-        },
+    /**
+     * Warms the long-name/system-name caches for the given tables of a schema, in one round trip per batch
+     * rather than the one-per-table lookups {@link #getSystemName} and {@link #getLongName} would otherwise
+     * each make on a cache miss.
+     * <p>
+     * Scoped to the tables asked for, not to the whole schema. Only captured tables are ever looked up
+     * afterwards, so fetching a mapping for every table in the library made schema discovery scale with the
+     * size of the source rather than with {@code table.include.list} - hundreds of rows and tens of seconds
+     * on every connector start on a long-lived IBM i system, undoing the scoping the column read before it
+     * already applies. A table missing from the result is not an error: it resolves lazily on first use.
+     */
+    public void getAllSystemNames(String schemaName, Collection<String> tableNames) throws SQLException, InterruptedException {
+        final List<String> names = tableNames.stream().map(String::toUpperCase).distinct().toList();
+        int fetched = 0;
+        for (int from = 0; from < names.size(); from += SYSTEM_NAME_BATCH_SIZE) {
+            fetched += fetchSystemNames(schemaName, names.subList(from, Math.min(from + SYSTEM_NAME_BATCH_SIZE, names.size())));
+        }
+        log.info("fetched {} name mappings for the {} captured tables of schema {}", fetched, names.size(), schemaName);
+    }
+
+    private int fetchSystemNames(String schemaName, List<String> tableNames) throws SQLException, InterruptedException {
+        final String placeholders = tableNames.stream().map(n -> "?").collect(Collectors.joining(", "));
+        // the blocking consumer returns nothing, so the row count comes back in a holder
+        final int[] fetched = { 0 };
+        prepareQueryWithBlockingConsumer(String.format(GET_SYSTEM_TABLE_NAMES, placeholders),
+                call -> {
+                    call.setString(1, schemaName);
+                    for (int i = 0; i < tableNames.size(); i++) {
+                        call.setString(i + 2, tableNames.get(i));
+                        call.setString(i + 2 + tableNames.size(), tableNames.get(i));
+                    }
+                },
                 rs -> {
                     while (rs.next()) {
                         final String systemName = rs.getString(1);
@@ -340,10 +380,10 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                         longToSystemTableName.put(longKey, Optional.of(systemName));
                         final String shortKey = String.format("%s.%s", schemaName, systemName);
                         systemToLongTableName.put(shortKey, tableName);
-
+                        fetched[0]++;
                     }
                 });
-        log.info("fetched {} long names", longToSystemTableName.size());
+        return fetched[0];
     }
 
     public Optional<String> getSystemName(String schemaName, String longTableName) {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -277,10 +277,17 @@ public class As400SnapshotChangeEventSource
                     connectorConfig.getTableFilters().eligibleDataCollectionFilter(), null, false);
 
             try {
-                jdbcConnection.getAllSystemNames(schema);
+                // scoped to this schema's captured tables for the same reason as the read above: the
+                // mapping is only ever consulted for those, and fetching the whole library's worth cost
+                // tens of seconds of round trips on every start
+                final Set<String> capturedInSchema = snapshotContext.capturedTables.stream()
+                        .filter(id -> schema.equals(id.schema()))
+                        .map(TableId::table)
+                        .collect(Collectors.toSet());
+                jdbcConnection.getAllSystemNames(schema, capturedInSchema);
             }
             catch (final Exception e) {
-                log.warn("failure fetching table names", e);
+                log.warn("failure fetching table names for schema {}", schema, e);
             }
         }
 

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionSystemNamesTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionSystemNamesTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.jdbc.JdbcConnection.BlockingResultSetConsumer;
+import io.debezium.jdbc.JdbcConnection.StatementPreparer;
+
+/**
+ * Verifies that the long-name/system-name prefetch is scoped to the captured tables rather than to the
+ * whole schema. It used to run {@code select ... from qsys2.systables where system_table_schema=?} with no
+ * table predicate at all, so schema discovery scaled with the size of the source library instead of with
+ * {@code table.include.list} - 462 and 722 rows for ~41 captured tables on the deployment in issue #50,
+ * about 25s of round trips on every connector start.
+ *
+ * <p>The query is executed through {@code prepareQueryWithBlockingConsumer}, which is stubbed here to
+ * capture the statement text and the bound parameters; {@link As400JdbcConnection}'s constructor resolves
+ * the real database name eagerly and would otherwise need a live AS400.
+ */
+class As400JdbcConnectionSystemNamesTest {
+
+    private final As400JdbcConnection connection = mock(As400JdbcConnection.class, CALLS_REAL_METHODS);
+    private final List<String> statements = new ArrayList<>();
+    private final List<Map<Integer, String>> boundParameters = new ArrayList<>();
+
+    private void captureQueries() throws Exception {
+        doAnswer(invocation -> {
+            statements.add(invocation.getArgument(0));
+            final Map<Integer, String> bound = new LinkedHashMap<>();
+            final PreparedStatement statement = mock(PreparedStatement.class);
+            doAnswer(set -> bound.put(set.getArgument(0), set.getArgument(1)))
+                    .when(statement).setString(anyInt(), anyString());
+            invocation.getArgument(1, StatementPreparer.class).accept(statement);
+            boundParameters.add(bound);
+            // an empty result set: every mapping then resolves lazily, which is the documented fallback
+            final ResultSet resultSet = mock(ResultSet.class);
+            invocation.getArgument(2, BlockingResultSetConsumer.class).accept(resultSet);
+            return connection;
+        }).when(connection).prepareQueryWithBlockingConsumer(anyString(), any(), any());
+    }
+
+    @Test
+    void theQueryIsRestrictedToTheTablesAskedFor() throws Exception {
+        captureQueries();
+
+        connection.getAllSystemNames("MYLIB", Set.of("ORDERS", "CUSTOMERS"));
+
+        assertThat(statements).hasSize(1);
+        assertThat(statements.get(0))
+                .contains("system_table_schema=?")
+                // both names, because the captured set may hold either one
+                .contains("upper(table_name) in (?, ?)")
+                .contains("upper(replace(system_table_name, '\"', '')) in (?, ?)");
+
+        // the schema, then the table names once per column, upper-cased for the upper() comparisons
+        final Map<Integer, String> bound = boundParameters.get(0);
+        assertThat(bound).hasSize(5);
+        assertThat(bound.get(1)).isEqualTo("MYLIB");
+        assertThat(List.of(bound.get(2), bound.get(3))).containsExactlyInAnyOrder("ORDERS", "CUSTOMERS");
+        assertThat(List.of(bound.get(4), bound.get(5))).containsExactlyInAnyOrder("ORDERS", "CUSTOMERS");
+    }
+
+    @Test
+    void tableNamesAreUpperCasedToMatchTheCatalogComparison() throws Exception {
+        captureQueries();
+
+        connection.getAllSystemNames("MYLIB", Set.of("orders"));
+
+        assertThat(boundParameters.get(0).values()).containsExactly("MYLIB", "ORDERS", "ORDERS");
+    }
+
+    /**
+     * A whole-library include list would otherwise put thousands of bind parameters into one statement.
+     */
+    @Test
+    void aLargeCapturedSetIsSplitIntoBatches() throws Exception {
+        captureQueries();
+        final Set<String> tables = IntStream.range(0, 1_200).mapToObj(i -> "T" + i)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        connection.getAllSystemNames("MYLIB", tables);
+
+        // 500 + 500 + 200, and every table is asked about exactly once per column
+        assertThat(statements).hasSize(3);
+        assertThat(boundParameters.stream().map(Map::size)).containsExactly(1_001, 1_001, 401);
+        final List<String> namesAsked = boundParameters.stream()
+                .flatMap(bound -> bound.entrySet().stream().filter(e -> e.getKey() > 1).map(Map.Entry::getValue))
+                .toList();
+        assertThat(namesAsked).hasSize(2_400).containsAll(tables);
+    }
+
+    @Test
+    void nothingIsQueriedWhenNoTableIsCaptured() throws Exception {
+        captureQueries();
+
+        connection.getAllSystemNames("MYLIB", Set.of());
+
+        verify(connection, never()).prepareQueryWithBlockingConsumer(anyString(), any(), any());
+    }
+
+    /**
+     * A duplicate would double the placeholders for no gain; the captured set can hold a table under both
+     * its long and its system name.
+     */
+    @Test
+    void duplicateNamesAreAskedAboutOnce() throws Exception {
+        captureQueries();
+
+        connection.getAllSystemNames("MYLIB", List.of("ORDERS", "orders", "ORDERS"));
+
+        assertThat(statements.get(0)).contains("upper(table_name) in (?)");
+        assertThat(boundParameters.get(0).values()).containsExactly("MYLIB", "ORDERS", "ORDERS");
+    }
+}


### PR DESCRIPTION
Closes #50.

## What was wrong

`readTableStructure` already scopes the per-table column read to the include list, and says so in a comment:

```java
// reading info only for the schemas we're interested in as per the set of captured tables;
// while the passed table name filter alone would skip all non-included tables, reading the schema
// would take much longer that way
```

The `getAllSystemNames(schema)` call on the very next line undid it. The query carried no table predicate at all:

```sql
select trim(system_table_name), trim(table_name) from qsys2.systables where system_table_schema=?
```

So schema discovery scaled with the size of the source **library**, not with `table.include.list`. On a source with ~41 included tables across two schemas it fetched long/short-name mappings for 462 and 722 tables — the full contents of each — adding roughly 25s of pure round-trip to every connector start, for tables nothing would ever ask about.

## What this does

The prefetch now takes the schema's captured table names, and matches on either name, as loosely as `GET_TABLE_TYPE` does, because the captured set may hold a table under its long or its system name:

```sql
select trim(system_table_name), trim(table_name) from qsys2.systables
where system_table_schema=?
and (upper(table_name) in (%1$s) or upper(replace(system_table_name, '"', '')) in (%1$s))
```

## Why narrowing it cannot lose a mapping

Worth stating explicitly, since this is the risk a reviewer would look for: **both** directions already fall back to a per-table catalog lookup on a cache miss — `getSystemName` via `GET_SYSTEM_TABLE_NAME`, `getLongName` via `GET_TABLE_NAME`. So the bulk call is purely a prefetch. Anything not prefetched resolves lazily on first use, and since only captured tables are ever looked up at all, there is no extra lazy work either. Narrowing the prefetch can only shift work that never happens.

## Batching

Batched at 500 names, two bind parameters each, so a whole-library include list of several hundred tables cannot push one statement past a parameter limit. A 255-entry list is one query; a 1200-table one is three.

## Also in here

`log.info("fetched {} long names", longToSystemTableName.size())` reported the **cumulative** size of the cache rather than what the call had just done. It read as a per-schema count and was not one — on the second schema it silently included the first. It now reports the mappings found against the number of tables asked about, and the failure warning names the schema it was reading.

## Tests

`As400JdbcConnectionSystemNamesTest` stubs `prepareQueryWithBlockingConsumer` to capture the statement text and the bound parameters, covering: the `IN` list is sized to the tables and applied to both columns; names are upper-cased to match the `upper()` comparisons; parameters land at the right positions for both columns; 1200 tables split into 500/500/200 with every table asked about exactly once per column; duplicates collapse; an empty captured set issues no query at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
