### PR TITLE
Null a blank-filled decimal instead of dropping the row (#52)

### DIFF
--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,6 +37,7 @@ import com.ibm.as400.access.AS400Text;
 import com.ibm.as400.access.AS400Time;
 import com.ibm.as400.access.AS400Timestamp;
 import com.ibm.as400.access.AS400ZonedDecimal;
+import com.ibm.as400.access.ExtendedIllegalArgumentException;
 
 import io.debezium.ibmi.db2.journal.data.types.AS400Boolean;
 import io.debezium.ibmi.db2.journal.data.types.AS400Lob;
@@ -106,6 +108,8 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
      * Entry specific data
      */
     private final AS400Text lengthDecoder;
+    /** Rows seen per undecodable (library.file.column), to keep the warning from repeating per row. */
+    private final Map<String, AtomicLong> undecodableColumnCounts = new ConcurrentHashMap<>();
     private static final Object[] EMPTY = new Object[]{};
     private static final byte[] EMPTY_BYTES = new byte[0];
 
@@ -119,11 +123,16 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
             final int length = Integer.parseInt(lengthStr);
             if (length > 0) {
                 final List<LobField> lobFields = new ArrayList<>();
+                final List<UndecodableField> undecodable = new ArrayList<>();
                 final Object[] os = decodeEntry(tableInfo.getAs400Structure(), data,
                         offset + entryHeader.getEntrySpecificDataOffset() + ENTRY_SPECIFIC_DATA_OFFSET, isNull,
-                        lobFields);
+                        lobFields, undecodable);
                 if (!lobFields.isEmpty()) {
                     resolveLobs(entryHeader, tableInfo, os, lobFields, length);
+                }
+                if (!undecodable.isEmpty()) {
+                    // reported here rather than in decodeEntry, which knows the types but not the column names
+                    reportUndecodable(entryHeader, tableInfo, undecodable);
                 }
                 return os;
             }
@@ -147,12 +156,19 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
         return decodeEntry(entryDetailStructure, data, offset, isNull, new ArrayList<>());
     }
 
-    /**
-     * @param lobFields collects the LOB columns found, in column order, for
-     *                  {@link #resolveLobs} to fill in - their value is never in the record image
-     */
     public Object[] decodeEntry(AS400Structure entryDetailStructure, byte[] data, int offset, boolean[] isNull,
                                 List<LobField> lobFields) {
+        return decodeEntry(entryDetailStructure, data, offset, isNull, lobFields, new ArrayList<>());
+    }
+
+    /**
+     * @param lobFields   collects the LOB columns found, in column order, for
+     *                    {@link #resolveLobs} to fill in - their value is never in the record image
+     * @param undecodable collects the columns left null because their bytes could not be decoded, for the
+     *                    caller to report against the column names it knows
+     */
+    public Object[] decodeEntry(AS400Structure entryDetailStructure, byte[] data, int offset, boolean[] isNull,
+                                List<LobField> lobFields, List<UndecodableField> undecodable) {
         final AS400DataType[] members = entryDetailStructure.getMembers();
         final Object[] result = new Object[members.length];
         int fieldOffset = offset;
@@ -172,11 +188,103 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
                 lobFields.add(new LobField(i, lob, fieldIsNull, dataLength));
             }
             else if (!fieldIsNull) {
-                result[i] = member.toObject(data, fieldOffset);
+                if (isBlankFilledDecimal(member, data, fieldOffset)) {
+                    // a 0x40-filled numeric is how an uninitialised value is held in an old physical file,
+                    // not corruption, and the journal does not flag it null because the column is not
+                    // null-capable. Left null rather than handed to jt400, which would throw
+                    undecodable.add(new UndecodableField(i, member, null));
+                }
+                else {
+                    try {
+                        result[i] = member.toObject(data, fieldOffset);
+                    }
+                    catch (final NumberFormatException | ExtendedIllegalArgumentException e) {
+                        // one strict-typed column must not cost the whole record. The offset comes from
+                        // getByteLength(), not from the decode, so every field after this one stays
+                        // aligned; anything the driver rejects for other reasons (a record image that
+                        // does not match the format, say) still aborts the entry, because tolerating
+                        // that would produce plausible garbage instead of an attributable failure
+                        undecodable.add(new UndecodableField(i, member, e));
+                    }
+                }
             }
             fieldOffset += member.getByteLength();
         }
         return result;
+    }
+
+    /**
+     * A column left null because its bytes could not be decoded.
+     *
+     * @param cause what the driver threw, or {@code null} when the field was blank-filled and so was never
+     *              offered to it
+     */
+    public record UndecodableField(int index, AS400DataType type, RuntimeException cause) {
+    }
+
+    /** EBCDIC space, what an uninitialised fixed-width field is filled with. */
+    private static final byte EBCDIC_BLANK = 0x40;
+
+    /**
+     * Whether a zoned or packed decimal field holds nothing but EBCDIC blanks, the legacy encoding for "no
+     * value" in physical files old enough to predate null-capable columns. Cheaper than letting jt400 throw,
+     * and it separates the expected case from a genuinely corrupt one in the log.
+     */
+    private static boolean isBlankFilledDecimal(AS400DataType member, byte[] data, int offset) {
+        if (!(member instanceof AS400PackedDecimal) && !(member instanceof AS400ZonedDecimal)) {
+            return false;
+        }
+        final int end = offset + member.getByteLength();
+        if (offset < 0 || end > data.length) {
+            // truncated: let the driver report it, the record image does not match the format
+            return false;
+        }
+        for (int at = offset; at < end; at++) {
+            if (data[at] != EBCDIC_BLANK) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Warns about columns that decoded to null, once per (table, column) and then on each power of ten, so a
+     * column that fails on every row of a hot table states the problem and its running total without
+     * drowning the log - the pre-existing behaviour was one line per row, at 24 an hour on the deployment in
+     * issue #52.
+     */
+    private void reportUndecodable(EntryHeader entryHeader, TableInfo tableInfo, List<UndecodableField> fields) {
+        final List<Structure> columns = tableInfo.getStructure();
+        for (final UndecodableField field : fields) {
+            final String column = field.index() < columns.size()
+                    ? columns.get(field.index()).getName()
+                    : "#" + field.index();
+            final String key = String.format("%s.%s.%s", entryHeader.getLibrary(), entryHeader.getFile(), column);
+            final long seen = undecodableColumnCounts.computeIfAbsent(key, k -> new AtomicLong()).incrementAndGet();
+            if (!isFirstOrPowerOfTen(seen)) {
+                continue;
+            }
+            if (field.cause() == null) {
+                log.warn("column {} of {}.{} is blank-filled and not flagged null, read as null instead of "
+                        + "failing the record ({} rows so far)", column, entryHeader.getLibrary(),
+                        entryHeader.getFile(), seen);
+            }
+            else {
+                log.warn("column {} of {}.{} could not be decoded as {}, read as null instead of failing the "
+                        + "record ({} rows so far)", column, entryHeader.getLibrary(), entryHeader.getFile(),
+                        field.type().getClass().getSimpleName(), seen, field.cause());
+            }
+        }
+    }
+
+    /** 1, 10, 100, ...: enough to state the magnitude of a column that fails on every row, without a line per row. */
+    private static boolean isFirstOrPowerOfTen(long count) {
+        for (long at = 1; at > 0 && at <= count; at *= 10) {
+            if (at == count) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoderTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoderTest.java
@@ -7,6 +7,7 @@ package io.debezium.ibmi.db2.journal.retrieve;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -212,6 +213,114 @@ public class JdbcFileDecoderTest {
         assertEquals("ABC", result[0]);
         assertEquals(0, new BigDecimal(123).compareTo((BigDecimal) result[1]));
         assertEquals("ZZ", result[2]);
+    }
+
+    /**
+     * The gap #9's isNull skip left open, and the whole point of issue #52: a blank-filled numeric that the
+     * journal does <em>not</em> flag null - a non-null-capable column that was never initialised, i.e. the
+     * ordinary legacy pattern - used to reach jt400 and throw, which aborted the entry and dropped the whole
+     * row. It must now cost that one column and nothing else.
+     */
+    @Test
+    public void testDecodeEntryNullsABlankPackedDecimalThatIsNotFlaggedNull() {
+        final AS400Structure structure = threeFieldStructure();
+        final byte[] data = structure.toBytes(new Object[]{ "ABC", new BigDecimal(123), "ZZ" });
+        blankFill(data, 3, 6); // the DECIMAL(5,0), untouched by the indicator array below
+
+        final List<JdbcFileDecoder.UndecodableField> undecodable = new ArrayList<>();
+        final Object[] result = DECODER.decodeEntry(structure, data, 0, new boolean[]{ false, false, false },
+                new ArrayList<>(), undecodable);
+
+        assertNull(result[1]);
+        // and, the part that was being lost, every other column of the row is intact
+        assertEquals("ABC", result[0]);
+        assertEquals("ZZ", result[2]);
+        assertEquals(1, undecodable.size());
+        assertEquals(1, undecodable.get(0).index());
+        // blank-filled, so it was never offered to the driver and there is nothing to attribute
+        assertNull(undecodable.get(0).cause());
+    }
+
+    @Test
+    public void testDecodeEntryNullsABlankZonedDecimalThatIsNotFlaggedNull() {
+        // [CHAR(3), ZONED(5,0), CHAR(2)] -> 3 + 5 + 2 = 10 bytes
+        final AS400Structure structure = new AS400Structure(
+                new AS400DataType[]{ new AS400Text(3), new AS400ZonedDecimal(5, 0), new AS400Text(2) });
+        final byte[] data = structure.toBytes(new Object[]{ "ABC", new BigDecimal(123), "ZZ" });
+        blankFill(data, 3, 8);
+
+        final List<JdbcFileDecoder.UndecodableField> undecodable = new ArrayList<>();
+        final Object[] result = DECODER.decodeEntry(structure, data, 0, null, new ArrayList<>(), undecodable);
+
+        assertNull(result[1]);
+        assertEquals("ABC", result[0]);
+        assertEquals("ZZ", result[2]);
+        assertEquals(1, undecodable.size());
+    }
+
+    /**
+     * The backstop for bytes that are not blank but that the driver still rejects - the NumberFormatException
+     * on a bad nibble that issue #52 was filed on. Same outcome: one null column, not a dropped row.
+     */
+    @Test
+    public void testDecodeEntryNullsAPackedDecimalTheDriverRejects() {
+        final AS400Structure structure = threeFieldStructure();
+        final byte[] data = structure.toBytes(new Object[]{ "ABC", new BigDecimal(123), "ZZ" });
+        data[4] = 0x4A; // a non-blank, invalid nibble pair in the middle of the DECIMAL(5,0)
+
+        final List<JdbcFileDecoder.UndecodableField> undecodable = new ArrayList<>();
+        final Object[] result = DECODER.decodeEntry(structure, data, 0, null, new ArrayList<>(), undecodable);
+
+        assertNull(result[1]);
+        assertEquals("ABC", result[0]);
+        assertEquals("ZZ", result[2]);
+        assertEquals(1, undecodable.size());
+        // this one did come from the driver, so it is attributable
+        assertNotNull(undecodable.get(0).cause());
+    }
+
+    /**
+     * A blank value is the legacy "no value", so it must not be confused with a real zero, which is what
+     * silently defaulting the column would have produced.
+     */
+    @Test
+    public void testDecodeEntryStillReadsARealZero() {
+        final AS400Structure structure = threeFieldStructure();
+        final byte[] data = structure.toBytes(new Object[]{ "ABC", BigDecimal.ZERO, "ZZ" });
+
+        final List<JdbcFileDecoder.UndecodableField> undecodable = new ArrayList<>();
+        final Object[] result = DECODER.decodeEntry(structure, data, 0, null, new ArrayList<>(), undecodable);
+
+        assertEquals(0, BigDecimal.ZERO.compareTo((BigDecimal) result[1]));
+        assertEquals(0, undecodable.size());
+    }
+
+    /** A blank CHAR column is a blank string, not a missing value: only decimals get this treatment. */
+    @Test
+    public void testDecodeEntryLeavesBlankTextAlone() {
+        final AS400Structure structure = threeFieldStructure();
+        final byte[] data = structure.toBytes(new Object[]{ "ABC", new BigDecimal(123), "ZZ" });
+        blankFill(data, 0, 3);
+
+        final List<JdbcFileDecoder.UndecodableField> undecodable = new ArrayList<>();
+        final Object[] result = DECODER.decodeEntry(structure, data, 0, null, new ArrayList<>(), undecodable);
+
+        assertEquals("   ", result[0]);
+        assertEquals(0, undecodable.size());
+    }
+
+    /**
+     * A record image that does not match the format is a different problem: tolerating it per field would
+     * hand plausible garbage downstream, so it must still abort the entry, where the streaming loop logs it
+     * with an offset and an RRN to attribute it (issue #31).
+     */
+    @Test
+    public void testDecodeEntryStillFailsOnATruncatedRecord() {
+        final AS400Structure structure = threeFieldStructure();
+        final byte[] data = new byte[structure.getByteLength() - 3];
+
+        assertThrows(RuntimeException.class,
+                () -> DECODER.decodeEntry(structure, data, 0, null, new ArrayList<>(), new ArrayList<>()));
     }
 
     private static final int LOB_RECORD_OFFSET = 5;


### PR DESCRIPTION
Closes #52.

## What was wrong

A `0x40`-filled zoned or packed decimal aborted the decode of its **entire** journal entry, so the whole row was dropped instead of arriving with one null column. Blank numerics are not corruption — they are the normal legacy encoding for "no value" in physical files old enough to predate null-capable columns — so the loss was permanent and recurring: 12 occurrences per 30 min on one column of one table on the deployment in the issue, every update to it lost at the target.

#9 added the `isNull` skip for exactly this byte pattern, and its javadoc names *blank-filled packed decimal* as the motivation, but the guard is the journal's null-indicator map:

```java
final boolean fieldIsNull = isNull != null && i < isNull.length && isNull[i];
...
else if (!fieldIsNull) {
    result[i] = member.toObject(data, fieldOffset);   // <-- throws here
}
```

A field that is blank-filled and **not** flagged null — a non-null-capable column that was never initialised, i.e. the ordinary legacy pattern — still reached `member.toObject`, and `decodeEntry` had no per-field catch, so one strict-typed column cost the whole record.

## What this does

1. **Blank-filled decimals are recognised before the driver is called.** All bytes `0x40` in an `AS400PackedDecimal` or `AS400ZonedDecimal` means uninitialised, not a decode error — cheaper than catching and it separates the expected case from a genuinely corrupt one.
2. **`NumberFormatException` / `ExtendedIllegalArgumentException` from any field is caught** and leaves that column null. The offset comes from `member.getByteLength()`, not from the decode, so every field after a rejected one stays aligned.
3. **Attribution is throttled**, once per (table, column) and then on each power of ten, with a running count.
4. **Decoder tests** for the blank-but-not-flagged path, which is why this half went unnoticed — #9's change was only covered for the flagged-null path.

## The line I drew, and why

Anything else the driver throws **still aborts the entry**. Catching `RuntimeException` broadly would have been easy, but a record image that does not match the format fails per-field in ways that produce plausible garbage silently, whereas the whole-record skip at least gets logged with an offset and an RRN (#31). Tolerating one bad value is strictly better than dropping the row; tolerating a structural mismatch is not. `testDecodeEntryStillFailsOnATruncatedRecord` pins that boundary.

## On the logging

The reporting is done by `decodeFile`, not `decodeEntry`: the decoder knows the types but not the column names, and the caller has `TableInfo.getStructure()`. `decodeEntry` hands the failures out through a collector list, the same shape as the existing `lobFields` parameter.

Blank fields and driver rejections are reported **separately** — one is expected legacy data, the other is not — so a real decode problem is not buried in the noise of a column that is merely uninitialised. Only the second carries the exception.

The old behaviour was one ERROR per row: 24/h from a single column on this deployment. Now it is one WARN at 1, 10, 100, ... rows, each naming the column, the table and the running total, which is the signal the issue asked for ("column X of table Y has undecodable values, N so far").

## Verified against the real failure

The pre-fix probe reproduces the production signature from the issue exactly:

```
java.lang.NumberFormatException: Low-order nibble of the byte at array offset 5 is not valid.  Byte value: 40.
	at com.ibm.as400.access.AS400PackedDecimal.throwNumberFormatException(AS400PackedDecimal.java:622)
```

Both new decode paths throw on `origin/3.5` and pass here. Tests also assert a real `0` still reads as `0` (a blank must not become a zero) and that a blank `CHAR` column is still a blank string — only decimals get this treatment.

## A correction to the issue

The `AS400Boolean` precedent the issue cites as "already tolerating a bad strict-type value" is weaker than it looks. `toBoolean` **throws** `ExtendedIllegalArgumentException` on anything but 0/1, and `DEFAULT_VALUE` is only reachable through `getDefaultValue()`, which the decode path never calls. So blank booleans were being dropped too. They are now covered by the catch rather than by a special case, which leaves 0/1 decoding untouched — deliberately, since making blank booleans `null` instead of `FALSE` via the fast path would have been a behaviour change beyond this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
