### PR TITLE
Name the table.include.list entries that resolve to nothing (#49)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -7,9 +7,12 @@ package io.debezium.connector.db2as400;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -33,6 +36,7 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.Selectors;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
@@ -252,6 +256,32 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     /** The raw {@code table.include.list} as supplied (e.g. {@code PYP31."$SCHAR"}), for the journal path. */
     public String getRawTableIncludeList() {
         return config.getString(TABLE_INCLUDE_LIST);
+    }
+
+    /**
+     * Every {@code table.include.list} entry paired with the predicate the table filters apply on its
+     * behalf, so a caller can tell which entries matched nothing on the source. Built with the same builder
+     * and the same {@link #tableToString} mapper as {@link #getTableFilters()}, so an entry that matches
+     * nothing here matches nothing there either.
+     * <p>
+     * Keyed by the entry as configured rather than by its normalized form: the regex-escaped version is an
+     * implementation detail, the configured one is what an operator can act on.
+     */
+    public Map<String, Predicate<TableId>> getTableIncludeListMatchers() {
+        final String includeList = getRawTableIncludeList();
+        if (includeList == null || includeList.isBlank()) {
+            return Map.of();
+        }
+        final Map<String, Predicate<TableId>> matchers = new LinkedHashMap<>();
+        for (final String raw : includeList.split(",")) {
+            final String entry = raw.trim();
+            if (!entry.isEmpty()) {
+                matchers.put(entry, Selectors.tableSelector()
+                        .includeTables(normalizeTablePattern(entry), tableToString)
+                        .build());
+            }
+        }
+        return matchers;
     }
 
     /** Escapes AS400 table names with regex metacharacters so they match as literals. */

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -201,6 +202,28 @@ public class As400SnapshotChangeEventSource
         }
     }
 
+    /**
+     * Names the {@code table.include.list} entries that matched no table on the source.
+     * <p>
+     * They are skipped by design - #33 settled that the include list is an allow list and that a table
+     * missing from the source must not block startup - but the skip left no trace anywhere, not even at
+     * DEBUG. On a connector configured for ~41 tables across two schemas only ~30 ever appeared in the
+     * "Adding table" lines and the rest showed up in neither direction, so the only way to tell "never
+     * captured because it does not exist" from "captured fine" was to diff the configured list against the
+     * log by hand. Nothing about which tables are captured changes here.
+     */
+    private void logUnresolvedIncludeListEntries(Set<TableId> capturedTables) {
+        final Map<String, Predicate<TableId>> matchers = connectorConfig.getTableIncludeListMatchers();
+        final List<String> unresolved = matchers.entrySet().stream()
+                .filter(entry -> capturedTables.stream().noneMatch(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .toList();
+        if (!unresolved.isEmpty()) {
+            log.info("{} of the {} table.include.list entries matched no table on the source and will not be "
+                    + "captured: {}", unresolved.size(), matchers.size(), String.join(", ", unresolved));
+        }
+    }
+
     @Override
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext,
                                                RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext)
@@ -259,6 +282,8 @@ public class As400SnapshotChangeEventSource
             throws Exception {
         final Set<String> schemas = snapshotContext.capturedTables.stream().map(TableId::schema)
                 .collect(Collectors.toSet());
+
+        logUnresolvedIncludeListEntries(snapshotContext.capturedTables);
 
         // reading info only for the schemas we're interested in as per the set of
         // captured tables;

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigIncludeListMatchersTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigIncludeListMatchersTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.TableId;
+
+/**
+ * Verifies {@link As400ConnectorConfig#getTableIncludeListMatchers()}, which lets schema discovery name the
+ * {@code table.include.list} entries that resolved to no table on the source (issue #49). Those entries are
+ * dropped by design - #33 made the include list an allow list - but the skip used to leave no trace at all,
+ * so a table that was never captured because it does not exist looked exactly like one that works.
+ *
+ * <p>What matters here is that an entry is only ever reported as unresolved when the connector really is not
+ * capturing it: the matchers must agree with the filters the connector actually applies.
+ */
+public class As400ConnectorConfigIncludeListMatchersTest {
+
+    private As400ConnectorConfig configWith(String includeList) {
+        return new As400ConnectorConfig(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, "LIB1")
+                .with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, includeList)
+                .build());
+    }
+
+    /** What schema discovery does: an entry no captured table matches is an entry that resolved to nothing. */
+    private static List<String> unresolvedAgainst(As400ConnectorConfig config, List<TableId> captured) {
+        return config.getTableIncludeListMatchers().entrySet().stream()
+                .filter(entry -> captured.stream().noneMatch(entry.getValue()))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    @Test
+    public void everyConfiguredEntryGetsAMatcher() {
+        final Map<String, Predicate<TableId>> matchers = configWith("LIB1.T1, LIB2.T2 ,LIB1.T3").getTableIncludeListMatchers();
+
+        // keyed by the entry as configured, trimmed, and in the order given
+        assertThat(matchers.keySet()).containsExactly("LIB1.T1", "LIB2.T2", "LIB1.T3");
+    }
+
+    @Test
+    public void anEmptyIncludeListHasNoMatchers() {
+        assertThat(configWith("").getTableIncludeListMatchers()).isEmpty();
+    }
+
+    @Test
+    public void onlyTheEntriesWithNoMatchingTableAreReported() {
+        final As400ConnectorConfig config = configWith("LIB1.PRESENT,LIB1.GONE,LIB2.ALSOGONE");
+
+        final List<String> unresolved = unresolvedAgainst(config,
+                List.of(new TableId("serverX", "LIB1", "PRESENT"), new TableId("serverX", "LIB1", "OTHER")));
+
+        assertThat(unresolved).containsExactly("LIB1.GONE", "LIB2.ALSOGONE");
+    }
+
+    @Test
+    public void nothingIsReportedWhenEveryEntryResolves() {
+        final As400ConnectorConfig config = configWith("LIB1.T1,LIB2.T2");
+
+        final List<String> unresolved = unresolvedAgainst(config,
+                List.of(new TableId("serverX", "LIB1", "T1"), new TableId("serverX", "LIB2", "T2")));
+
+        assertThat(unresolved).isEmpty();
+    }
+
+    /**
+     * The false positive to avoid: a name with a regex metacharacter is escaped before the filters see it,
+     * so the matcher has to be built from the same normalized form or a table that is being captured
+     * perfectly well would be reported as missing on every start.
+     */
+    @Test
+    public void anEntryWithARegexMetacharacterStillMatchesItsTable() {
+        final As400ConnectorConfig config = configWith("LIB1.$SCHAR,LIB1.\"$QUOTED\"");
+
+        final List<String> unresolved = unresolvedAgainst(config,
+                List.of(new TableId("serverX", "LIB1", "$SCHAR"), new TableId("serverX", "LIB1", "$QUOTED")));
+
+        assertThat(unresolved).isEmpty();
+    }
+
+    /**
+     * The matchers exist to describe the filters, so they must not claim a table is captured when the
+     * connector's own filter disagrees - which is what makes the reported list trustworthy.
+     */
+    @Test
+    public void theMatchersAgreeWithTheFilterTheConnectorApplies() {
+        final As400ConnectorConfig config = configWith("LIB1.T1,LIB1.$SCHAR,LIB1.GONE");
+        final List<TableId> candidates = List.of(
+                new TableId("serverX", "LIB1", "T1"),
+                new TableId("serverX", "LIB1", "$SCHAR"),
+                new TableId("serverX", "LIB1", "NOTINCLUDED"));
+
+        for (final TableId candidate : candidates) {
+            final boolean anyMatcherAccepts = config.getTableIncludeListMatchers().values().stream()
+                    .anyMatch(matcher -> matcher.test(candidate));
+            assertThat(anyMatcherAccepts)
+                    .as("matcher verdict for %s must equal the connector's data collection filter", candidate)
+                    .isEqualTo(config.getTableFilters().dataCollectionFilter().isIncluded(candidate));
+        }
+    }
+}


### PR DESCRIPTION
Closes #49.

## What was wrong

An include-list entry that matches no table on the source was dropped with **no log trace at all** — not even at DEBUG. On a connector configured for ~41 tables across two schemas, only ~30 ever appeared in the "Adding table ... to the list of capture schema tables" output; the rest showed up nowhere, in either direction. The only way to tell "never captured because it does not exist on the source" from "captured fine" was to diff the configured include list against the log by hand.

## What this does

Schema discovery emits one INFO line naming them:

```
INFO  2 of the 41 table.include.list entries matched no table on the source and will not be captured: AR.<table>, DW.<table>
```

#33's semantics are untouched: the list is still an allow list, a table missing from the source still does not block startup, and which tables get captured does not change. The quiet skip is just no longer invisible.

## The design choice worth reviewing

The matchers come from the **same** `Selectors` builder and the **same** `tableToString` mapper the connector's own filters use, rather than from a string comparison against `schema.table`:

```java
matchers.put(entry, Selectors.tableSelector()
        .includeTables(normalizeTablePattern(entry), tableToString)
        .build());
```

That is what keeps the report honest in both directions. A string comparison would have been shorter but would produce false positives in two real cases:

- a genuine wildcard/regex entry, which matches tables that no literal comparison would find;
- a name that had to be regex-escaped — the `LIB1.$SCHAR` case `normalizeTablePattern` already handles — which would be reported as missing on **every** connector start while being captured perfectly well.

By construction, an entry is now reported as unresolved exactly when the connector's real filter also matches nothing. `theMatchersAgreeWithTheFilterTheConnectorApplies` asserts that equivalence against `getTableFilters().dataCollectionFilter()` directly, so the two cannot drift apart silently.

Entries are keyed and reported in their **configured** form, not the escaped one: the operator can act on what they typed, not on `Pattern.quote` output.

## Log level

INFO, as the issue proposed: one-time, low-volume, and an actionable fact about the connector's effective configuration. The line carries the count as well as the names (`2 of the 41`), so it is useful even when the list is long. Say the word if you would rather have DEBUG.

## Tests

`As400ConnectorConfigIncludeListMatchersTest`: every configured entry gets a matcher, keyed trimmed and in order; an empty include list yields none; only entries with no matching table are reported; nothing is reported when everything resolves; a `$`-bearing name (bare and quoted) still matches its table; and the filter-equivalence check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
