### PR TITLE
Log the record image in hex when a journal entry or field is skipped (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ side.
 > `errors.tolerance` is the same property name and the same `none`/`all` values as Kafka Connect's own,
 > which governs converter/transform/producer errors; the setting is shared and the intent is the same.
 
+### Journal entries that cannot be processed
+
+A journal entry the connector cannot decode or dispatch is skipped with one **ERROR** line naming the offset,
+table, RRN, journal code and entry type, and the position moves past it. A single field that cannot be decoded
+(a blank-filled numeric, say) does not cost the row: it is read as null and logged at **WARN** with the column
+name, once per row-count decade. Both lines end with the row's **record image in hex** (the bytes after the
+journal entry's 16-byte length prefix, capped at 4 KiB), so the offending column can be checked by hand from the
+log alone: slice `2 * byteLength` hex characters per column in table-format order. `4040…` is an uninitialised
+field, random bytes are corruption, a valid-looking pattern that is shifted means the table format changed
+after the entry was journaled. The RRN is what the customer needs to locate the row.
+
 ## Memory
 
 Recommended minimum memory 1GB

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -24,6 +24,7 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.db2as400.As400ConnectorConfig.UnavailablePositionRecovery;
 import io.debezium.connector.db2as400.As400RpcConnection.BlockingReceiverConsumer;
 import io.debezium.data.Envelope.Operation;
+import io.debezium.ibmi.db2.journal.data.types.Diagnostics;
 import io.debezium.ibmi.db2.journal.retrieve.JournalEntryType;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.exception.FatalException;
@@ -534,10 +535,12 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                 throw e;
             }
             catch (final Exception e) {
+                // same line as the throwable, so the dead-letter record carries the row bytes
                 log.error("Failed to process record at offset = " + eheader.getSequenceNumber() + "  in table = " + longName +
                         " at RRN = " + eheader.getRelativeRecordNumber() + " [journalCode = " + eheader.getJournalCode() + ", journalEntryType = "
                         + eheader.getJournalEntryType() + "], " +
-                        "skipping and dumping diagnostics if enabled ...", e);
+                        "skipping and dumping diagnostics if enabled ... record image (hex) = "
+                        + r.currentRecordImageHex(Diagnostics.MAX_LOGGED_RECORD_BYTES), e);
             }
         };
     }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceSkipLogTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceSkipLogTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.db2as400.As400RpcConnection.BlockingReceiverConsumer;
+import io.debezium.ibmi.db2.journal.retrieve.JdbcFileDecoder;
+import io.debezium.ibmi.db2.journal.retrieve.JournalEntryType;
+import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
+import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
+import io.debezium.ibmi.db2.journal.retrieve.RetrieveJournal;
+import io.debezium.ibmi.db2.journal.retrieve.rjne0200.EntryHeader;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/** The skip ERROR line feeds the dead-letter queue, so it must keep its wording and carry the row bytes. */
+public class As400StreamingChangeEventSourceSkipLogTest {
+
+    private static final String DATABASE = "DTEST";
+    private static final String LIBRARY = "LIB";
+    private static final String TABLE = "CUSTOMERS";
+    private static final BigInteger SEQUENCE = BigInteger.valueOf(12345);
+    private static final BigInteger RRN = BigInteger.valueOf(7);
+    private static final String RECORD_IMAGE_HEX = "c1c2c34040";
+
+    private static final class SingleIterationContext implements ChangeEventSourceContext {
+        private final AtomicInteger runningChecks = new AtomicInteger();
+
+        @Override
+        public boolean isRunning() {
+            return runningChecks.getAndIncrement() == 0;
+        }
+
+        @Override
+        public boolean isPaused() {
+            return false;
+        }
+
+        @Override
+        public void streamingPaused() {
+        }
+
+        @Override
+        public void waitSnapshotCompletion() {
+        }
+
+        @Override
+        public void resumeStreaming() {
+        }
+
+        @Override
+        public void waitStreamingPaused() {
+        }
+    }
+
+    private final ListAppender<ILoggingEvent> logs = new ListAppender<>();
+    private Logger logger;
+
+    @BeforeEach
+    public void captureLog() {
+        logger = (Logger) LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
+        logs.start();
+        logger.addAppender(logs);
+    }
+
+    @AfterEach
+    public void releaseLog() {
+        logger.detachAppender(logs);
+    }
+
+    private static As400ConnectorConfig config() {
+        return new As400ConnectorConfig(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "server1")
+                .with(As400ConnectorConfig.DATABASE_NAME, DATABASE)
+                .with(As400ConnectorConfig.SCHEMA, LIBRARY)
+                .with(As400ConnectorConfig.TABLE_INCLUDE_LIST, LIBRARY + "." + TABLE)
+                .with(CommonConnectorConfig.POLL_INTERVAL_MS, 1)
+                .build());
+    }
+
+    private static JournalProcessedPosition positionAt(BigInteger offset, boolean processed) {
+        return new JournalProcessedPosition(offset, new JournalReceiver("RCV0001", "RCVLIB"), Instant.EPOCH, processed);
+    }
+
+    private static EntryHeader insertOnCapturedTable() {
+        final EntryHeader eheader = mock(EntryHeader.class);
+        when(eheader.getJournalEntryType()).thenReturn(JournalEntryType.ADD_ROW1);
+        when(eheader.getJournalCode()).thenReturn('R');
+        when(eheader.getLibrary()).thenReturn(LIBRARY);
+        when(eheader.getFile()).thenReturn(TABLE);
+        when(eheader.getSequenceNumber()).thenReturn(SEQUENCE);
+        when(eheader.getRelativeRecordNumber()).thenReturn(RRN);
+        when(eheader.getCommitCycle()).thenReturn(BigInteger.ZERO);
+        return eheader;
+    }
+
+    private static RetrieveJournal undecodableEntry() throws Exception {
+        final RetrieveJournal retrieveJournal = mock(RetrieveJournal.class);
+        when(retrieveJournal.decode(any())).thenThrow(new RuntimeException("boom"));
+        when(retrieveJournal.currentRecordImageHex(anyInt())).thenReturn(RECORD_IMAGE_HEX);
+        return retrieveJournal;
+    }
+
+    /** Mirrors {@link As400RpcConnection#getJournalEntries}: the position moves on only if the consumer returns. */
+    private static As400RpcConnection oneEntryBlock(RetrieveJournal retrieveJournal, EntryHeader eheader) throws Exception {
+        final As400RpcConnection dataConnection = mock(As400RpcConnection.class);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any())).thenAnswer(invocation -> {
+            final As400OffsetContext offsetContext = invocation.getArgument(1);
+            final BlockingReceiverConsumer consumer = invocation.getArgument(2);
+            consumer.accept(SEQUENCE, retrieveJournal, eheader);
+            offsetContext.getPosition().setPosition(positionAt(SEQUENCE, true));
+            return RetrievalState.Success;
+        });
+        return dataConnection;
+    }
+
+    private static As400JdbcConnection jdbcConnection() {
+        final As400JdbcConnection jdbcConnection = mock(As400JdbcConnection.class);
+        when(jdbcConnection.getRealDatabaseName()).thenReturn(DATABASE);
+        when(jdbcConnection.getLongName(LIBRARY, TABLE)).thenReturn(TABLE);
+        return jdbcConnection;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void skippedEntryIsLoggedOnceWithItsRecordImage() throws Exception {
+        final As400ConnectorConfig config = config();
+        final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
+        final As400DatabaseSchema schema = mock(As400DatabaseSchema.class);
+        when(schema.getFileDecoder()).thenReturn(mock(JdbcFileDecoder.class));
+        final As400OffsetContext offsetContext = new As400OffsetContext(config,
+                positionAt(SEQUENCE.subtract(BigInteger.ONE), true));
+
+        final As400StreamingChangeEventSource source = new As400StreamingChangeEventSource(config,
+                oneEntryBlock(undecodableEntry(), insertOnCapturedTable()), jdbcConnection(), dispatcher,
+                mock(ErrorHandler.class), Clock.SYSTEM, schema);
+
+        source.execute(new SingleIterationContext(), new As400Partition(config.getLogicalName()), offsetContext);
+
+        final List<ILoggingEvent> errors = logs.list.stream().filter(e -> e.getLevel() == Level.ERROR).toList();
+        assertThat(errors).hasSize(1);
+        final ILoggingEvent skip = errors.get(0);
+        assertThat(skip.getFormattedMessage())
+                .contains("offset = " + SEQUENCE)
+                .contains("in table = " + TABLE)
+                .contains("RRN = " + RRN)
+                .as("data-plane DLQ filter wording")
+                .contains("skipping and dumping diagnostics")
+                .contains("record image (hex) = " + RECORD_IMAGE_HEX);
+        assertThat(skip.getThrowableProxy()).isNotNull();
+        assertThat(skip.getThrowableProxy().getMessage()).isEqualTo("boom");
+
+        verify(dispatcher, never()).dispatchDataChangeEvent(any(), any(), any());
+        assertThat(offsetContext.getPosition().getOffset()).isEqualTo(SEQUENCE);
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/data/types/Diagnostics.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/data/types/Diagnostics.java
@@ -31,6 +31,27 @@ public class Diagnostics {
         }
     }
 
+    /** Cap on the record image bytes {@link #hex} puts in a log line. */
+    public static final int MAX_LOGGED_RECORD_BYTES = 4096;
+
+    /** Contiguous lowercase hex of {@code data[offset, offset + length)}, at most {@code maxBytes} bytes. Clamps, never throws. */
+    public static String hex(byte[] data, int offset, int length, int maxBytes) {
+        if (data == null || length <= 0 || offset < 0 || offset >= data.length) {
+            return "";
+        }
+        final int available = Math.min(length, data.length - offset);
+        final int shown = Math.min(available, Math.max(0, maxBytes));
+        final StringBuilder sb = new StringBuilder(shown * 2 + 40);
+        for (int i = 0; i < shown; i++) {
+            sb.append(Character.forDigit((data[offset + i] >> 4) & 0xf, 16));
+            sb.append(Character.forDigit(data[offset + i] & 0xf, 16));
+        }
+        if (shown < available) {
+            sb.append(" ...(truncated, ").append(available).append(" bytes total)");
+        }
+        return sb.toString();
+    }
+
     public static String binAsHex(byte[] data, int offset, int length) {
         // byte[] bdata = Arrays.copyOfRange(data, offset, offset + length);
         StringBuilder sb = new StringBuilder();

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JdbcFileDecoder.java
@@ -44,6 +44,7 @@ import io.debezium.ibmi.db2.journal.data.types.AS400Lob;
 import io.debezium.ibmi.db2.journal.data.types.AS400VarBin;
 import io.debezium.ibmi.db2.journal.data.types.AS400VarChar;
 import io.debezium.ibmi.db2.journal.data.types.As400TextFactory;
+import io.debezium.ibmi.db2.journal.data.types.Diagnostics;
 import io.debezium.ibmi.db2.journal.retrieve.JournalLobFetcher.LobSegment;
 import io.debezium.ibmi.db2.journal.retrieve.SchemaCacheIF.Structure;
 import io.debezium.ibmi.db2.journal.retrieve.SchemaCacheIF.TableInfo;
@@ -124,15 +125,16 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
             if (length > 0) {
                 final List<LobField> lobFields = new ArrayList<>();
                 final List<UndecodableField> undecodable = new ArrayList<>();
-                final Object[] os = decodeEntry(tableInfo.getAs400Structure(), data,
-                        offset + entryHeader.getEntrySpecificDataOffset() + ENTRY_SPECIFIC_DATA_OFFSET, isNull,
+                final int recordStart = offset + entryHeader.getEntrySpecificDataOffset() + ENTRY_SPECIFIC_DATA_OFFSET;
+                final Object[] os = decodeEntry(tableInfo.getAs400Structure(), data, recordStart, isNull,
                         lobFields, undecodable);
                 if (!lobFields.isEmpty()) {
                     resolveLobs(entryHeader, tableInfo, os, lobFields, length);
                 }
                 if (!undecodable.isEmpty()) {
                     // reported here rather than in decodeEntry, which knows the types but not the column names
-                    reportUndecodable(entryHeader, tableInfo, undecodable);
+                    reportUndecodable(entryHeader, tableInfo, undecodable,
+                            Diagnostics.hex(data, recordStart, length, Diagnostics.MAX_LOGGED_RECORD_BYTES));
                 }
                 return os;
             }
@@ -253,7 +255,8 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
      * drowning the log - the pre-existing behaviour was one line per row, at 24 an hour on the deployment in
      * issue #52.
      */
-    private void reportUndecodable(EntryHeader entryHeader, TableInfo tableInfo, List<UndecodableField> fields) {
+    private void reportUndecodable(EntryHeader entryHeader, TableInfo tableInfo, List<UndecodableField> fields,
+                                   String recordImageHex) {
         final List<Structure> columns = tableInfo.getStructure();
         for (final UndecodableField field : fields) {
             final String column = field.index() < columns.size()
@@ -266,13 +269,15 @@ public class JdbcFileDecoder extends JournalFileEntryDecoder {
             }
             if (field.cause() == null) {
                 log.warn("column {} of {}.{} is blank-filled and not flagged null, read as null instead of "
-                        + "failing the record ({} rows so far)", column, entryHeader.getLibrary(),
-                        entryHeader.getFile(), seen);
+                        + "failing the record ({} rows so far), RRN {} record image (hex) {}", column,
+                        entryHeader.getLibrary(), entryHeader.getFile(), seen, entryHeader.getRelativeRecordNumber(),
+                        recordImageHex);
             }
             else {
                 log.warn("column {} of {}.{} could not be decoded as {}, read as null instead of failing the "
-                        + "record ({} rows so far)", column, entryHeader.getLibrary(), entryHeader.getFile(),
-                        field.type().getClass().getSimpleName(), seen, field.cause());
+                        + "record ({} rows so far), RRN {} record image (hex) {}", column, entryHeader.getLibrary(),
+                        entryHeader.getFile(), field.type().getClass().getSimpleName(), seen,
+                        entryHeader.getRelativeRecordNumber(), recordImageHex, field.cause());
             }
         }
     }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournal.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournal.java
@@ -30,6 +30,7 @@ import com.ibm.as400.access.ProgramParameter;
 import com.ibm.as400.access.SecureAS400;
 import com.ibm.as400.access.ServiceProgramCall;
 
+import io.debezium.ibmi.db2.journal.data.types.Diagnostics;
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalCode;
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalEntryType;
 import io.debezium.ibmi.db2.journal.retrieve.exception.FatalException;
@@ -469,6 +470,15 @@ public class RetrieveJournal {
 
     public int getOffset() {
         return offset;
+    }
+
+    /** The current entry's record image as hex, capped at {@code maxBytes}; "" without a current entry. */
+    public String currentRecordImageHex(int maxBytes) {
+        if (entryHeader == null || outputData == null) {
+            return "";
+        }
+        final int start = offset + entryHeader.getEntrySpecificDataOffset() + JournalEntryDeocder.ENTRY_SPECIFIC_DATA_OFFSET;
+        return Diagnostics.hex(outputData, start, entryHeader.getLength() - JournalEntryDeocder.ENTRY_SPECIFIC_DATA_OFFSET, maxBytes);
     }
 
     public <T> T decode(JournalEntryDeocder<T> decoder) throws Exception {

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/data/types/DiagnosticsTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/data/types/DiagnosticsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.data.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class DiagnosticsTest {
+
+    private static final byte[] DATA = { 0x00, 0x40, (byte) 0xc1, (byte) 0xf9, 0x7f, (byte) 0x80, (byte) 0xff };
+
+    @Test
+    public void hexIsContiguousLowercaseOfTheRange() {
+        assertEquals("40c1f9", Diagnostics.hex(DATA, 1, 3, 100));
+    }
+
+    @Test
+    public void hexOfWholeBufferCoversEveryBytePattern() {
+        assertEquals("0040c1f97f80ff", Diagnostics.hex(DATA, 0, DATA.length, 100));
+    }
+
+    @Test
+    public void hexTruncatesAtMaxBytesAndSaysSo() {
+        assertEquals("0040 ...(truncated, 7 bytes total)", Diagnostics.hex(DATA, 0, DATA.length, 2));
+    }
+
+    @Test
+    public void hexClampsARangePastTheEndOfTheBuffer() {
+        assertEquals("80ff", Diagnostics.hex(DATA, 5, 50, 100));
+        assertEquals("80 ...(truncated, 2 bytes total)", Diagnostics.hex(DATA, 5, 50, 1));
+    }
+
+    @Test
+    public void hexIsEmptyForNothingToShow() {
+        assertEquals("", Diagnostics.hex(null, 0, 10, 100));
+        assertEquals("", Diagnostics.hex(DATA, 0, 0, 100));
+        assertEquals("", Diagnostics.hex(DATA, 0, -1, 100));
+        assertEquals("", Diagnostics.hex(DATA, DATA.length, 1, 100));
+        assertEquals("", Diagnostics.hex(DATA, -1, 1, 100));
+    }
+
+    @Test
+    public void zeroMaxBytesKeepsOnlyTheTotal() {
+        assertEquals(" ...(truncated, 7 bytes total)", Diagnostics.hex(DATA, 0, DATA.length, 0));
+    }
+}


### PR DESCRIPTION
Stop-gap for #51, scoped to what lets a skipped row be diagnosed from the log alone.

## Why
A journal entry the connector cannot decode is skipped with one ERROR line (offset, table, RRN, entry type) and a field that cannot be decoded (#52) is nulled with a WARN. Neither shows the bytes, so a corrupt field, an uninitialised field, a drifted table format and a decoder bug are indistinguishable. The diagnostics dump that would tell them apart writes the whole receiver buffer and is too large to reach Kafka at shutdown.

## What
- `Diagnostics.hex(...)`: contiguous lowercase hex of a byte range, capped at `MAX_LOGGED_RECORD_BYTES` (4 KiB) with a `...(truncated, N bytes total)` marker; clamps to the buffer, never throws.
- `RetrieveJournal.currentRecordImageHex(maxBytes)`: the current entry's row bytes after the 16-byte length prefix.
- Skipped-record ERROR in `As400StreamingChangeEventSource` ends with `record image (hex) = <hex>`. Message prefix, throwable and the `skipping and dumping diagnostics` wording are unchanged, so the data-plane DLQ filter and `IBMiDeadLetterQueueConfigTest` still match and the DLQ record carries the bytes.
- Nulled-field WARN in `JdbcFileDecoder.reportUndecodable` ends with `RRN <n> record image (hex) <hex>`; the once-per-decade rate limit per column is kept.
- README: how to slice the hex by column byte width.

## Tests
`DiagnosticsTest` (exact hex, truncation, clamping, empty inputs) and `As400StreamingChangeEventSourceSkipLogTest` (one ERROR with the filter wording and the hex, throwable is the cause, position advanced past the entry). `mvn -am -DskipITs test`: journal-parsing 172/172, debezium-connector-ibmi 93/93.

## Left open on #51
Counter, `errors.tolerance=none` failing the task, dump shrink/cap/naming, offline decoder, and the pre-existing `InterruptedException` swallowed by the same catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
