### PR TITLE
Prefetch the include list's catalog entries in one round trip per schema (#71)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,10 +59,11 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
     /**
      * Matches on either name, as loosely as {@link #GET_TABLE_TYPE}: the captured set may name a table by
      * its long or its system name, and {@code SYSTEM_TABLE_NAME} comes back delimited when it is not an
-     * ordinary identifier. The placeholder list is bound twice, once per column.
+     * ordinary identifier. The placeholder list is bound twice, once per column. The type comes along so the
+     * same round trip also answers {@link #getTableType}.
      */
     private static final String GET_SYSTEM_TABLE_NAMES = """
-            select trim(system_table_name), trim(table_name) from qsys2.systables
+            select trim(system_table_name), trim(table_name), trim(table_type) from qsys2.systables
             where system_table_schema=?
             and (upper(table_name) in (%1$s) or upper(replace(system_table_name, '"', '')) in (%1$s))
             """;
@@ -98,6 +100,8 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
 
     private final Map<String, String> systemToLongTableName = new HashMap<>();
     private final Map<String, Optional<String>> longToSystemTableName = new HashMap<>();
+    /** {@code TABLE_TYPE} by upper-cased {@code schema.name}, under both names, as {@link #GET_TABLE_TYPE} matches. */
+    private final Map<String, String> tableTypeByUpperName = new HashMap<>();
     private final String realDatabaseName;
 
     /**
@@ -156,9 +160,8 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         if (includes == null || includes.isBlank()) {
             return Collections.<FileFilter> emptyList();
         }
-        final String[] incs = includes.split(",");
-        final List<FileFilter> r = new ArrayList<>();
-        for (String tableName : incs) {
+        final List<IncludeEntry> entries = new ArrayList<>();
+        for (String tableName : includes.split(",")) {
             String schemaName = "";
             int o = tableName.lastIndexOf('.');
             if (o > 0) {
@@ -178,9 +181,33 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                 schemaName = schema;
             }
 
-            final String tableSchema = schemaName;
             // AS400 does not handle double-quote escaping, so remove them before building FileFilter object
-            final String bareTableName = tableName.replaceAll("\"", "");
+            entries.add(new IncludeEntry(schemaName, tableName.replaceAll("\"", "")));
+        }
+
+        // One round trip per schema; the per-table lookups below used to cost two each, serially, which put a
+        // hard ceiling on the include list at the task-start budget (issue #71). They remain the fallback.
+        final Map<String, List<String>> tablesBySchema = new LinkedHashMap<>();
+        for (final IncludeEntry entry : entries) {
+            tablesBySchema.computeIfAbsent(entry.schema(), k -> new ArrayList<>()).add(entry.table());
+        }
+        for (final Map.Entry<String, List<String>> perSchema : tablesBySchema.entrySet()) {
+            try {
+                getAllSystemNames(perSchema.getKey(), perSchema.getValue());
+            }
+            catch (final SQLException e) {
+                log.warn("failed to prefetch the catalog entries of schema {}, resolving its tables one by one", perSchema.getKey(), e);
+            }
+            catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("interrupted while prefetching the catalog entries of schema {}", perSchema.getKey(), e);
+            }
+        }
+
+        final List<FileFilter> r = new ArrayList<>();
+        for (final IncludeEntry entry : entries) {
+            final String tableSchema = entry.schema();
+            final String bareTableName = entry.table();
             final IncludedObject included = classify(tableSchema, bareTableName);
             if (included == IncludedObject.MISSING) {
                 log.error("dropping {}.{} from the journal filters, no such table - nothing will be captured for it",
@@ -195,6 +222,9 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
             getSystemName(tableSchema, bareTableName).map(x -> r.add(new FileFilter(tableSchema, x)));
         }
         return r;
+    }
+
+    private record IncludeEntry(String schema, String table) {
     }
 
     /** What the SQL catalog says about an entry of {@code table.include.list}. */
@@ -225,6 +255,10 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
 
     /** The {@code TABLE_TYPE} of a table named by its long or system name, null when there is no such object. */
     String getTableType(String schemaName, String tableName) throws SQLException {
+        final String cached = tableTypeByUpperName.get(typeKey(schemaName, tableName));
+        if (cached != null) {
+            return cached;
+        }
         return prepareQueryAndMap(GET_TABLE_TYPE,
                 call -> {
                     call.setString(1, schemaName);
@@ -233,6 +267,10 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                 },
                 singleResultMapper(rs -> rs.getString(1).trim(), (String) null,
                         String.format("no entry in qsys2.systables for %s.%s", schemaName, tableName)));
+    }
+
+    private static String typeKey(String schemaName, String tableName) {
+        return String.format("%s.%s", schemaName.toUpperCase(), tableName.toUpperCase());
     }
 
     /** Upper-cased long and system names of every file in the schema that still has a member; a file without one fails any SQL access with {@code SQL0204}. */
@@ -350,9 +388,15 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
      * size of the source rather than with {@code table.include.list} - hundreds of rows and tens of seconds
      * on every connector start on a long-lived IBM i system, undoing the scoping the column read before it
      * already applies. A table missing from the result is not an error: it resolves lazily on first use.
+     * Tables an earlier call already resolved are not asked about again.
      */
     public void getAllSystemNames(String schemaName, Collection<String> tableNames) throws SQLException, InterruptedException {
-        final List<String> names = tableNames.stream().map(String::toUpperCase).distinct().toList();
+        final List<String> names = tableNames.stream().map(String::toUpperCase).distinct()
+                .filter(name -> !tableTypeByUpperName.containsKey(typeKey(schemaName, name)))
+                .toList();
+        if (names.isEmpty()) {
+            return;
+        }
         int fetched = 0;
         for (int from = 0; from < names.size(); from += SYSTEM_NAME_BATCH_SIZE) {
             fetched += fetchSystemNames(schemaName, names.subList(from, Math.min(from + SYSTEM_NAME_BATCH_SIZE, names.size())));
@@ -376,10 +420,15 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
                     while (rs.next()) {
                         final String systemName = rs.getString(1);
                         final String tableName = rs.getString(2);
+                        final String tableType = rs.getString(3);
                         final String longKey = String.format("%s.%s", schemaName, tableName);
                         longToSystemTableName.put(longKey, Optional.of(systemName));
                         final String shortKey = String.format("%s.%s", schemaName, systemName);
                         systemToLongTableName.put(shortKey, tableName);
+                        if (tableType != null) {
+                            tableTypeByUpperName.put(typeKey(schemaName, tableName), tableType);
+                            tableTypeByUpperName.put(typeKey(schemaName, systemName.replace("\"", "")), tableType);
+                        }
                         fetched[0]++;
                     }
                 });

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionShortIncludesTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionShortIncludesTest.java
@@ -6,16 +6,22 @@
 package io.debezium.connector.db2as400;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
 
@@ -24,12 +30,19 @@ import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
  * from the SQL catalog without an RPC call: a table that does not exist is always dropped (Debezium
  * ignores include-list entries with no matching table), an SQL view only with {@code errors.tolerance=all}.
  *
+ * <p>Also covers the per-schema catalog prefetch that runs before the per-table lookups (issue #71).</p>
+ *
  * <p>Exercised through a {@code CALLS_REAL_METHODS} mock — {@link As400JdbcConnection}'s constructor
  * eagerly resolves the real database name and would otherwise require a live AS400.</p>
  */
 public class As400JdbcConnectionShortIncludesTest {
 
     private final As400JdbcConnection connection = mock(As400JdbcConnection.class, CALLS_REAL_METHODS);
+
+    @BeforeEach
+    void thePrefetchReturnsNothing() throws Exception {
+        doNothing().when(connection).getAllSystemNames(anyString(), any());
+    }
 
     @Test
     void tolerant_mode_skips_missing_tables_and_views() throws Exception {
@@ -74,5 +87,27 @@ public class As400JdbcConnectionShortIncludesTest {
         // Then the table that does not exist is dropped as Debezium drops it everywhere else, while the view
         // is kept and fails later, loudly, when its journal is resolved
         assertThat(includes).containsExactly(new FileFilter("LIB1", "T1"), new FileFilter("LIB1", "VUE10002"));
+    }
+
+    @Test
+    void the_include_list_is_prefetched_once_per_schema_before_any_per_table_lookup() throws Exception {
+        doReturn("T").when(connection).getTableType(anyString(), anyString());
+        doReturn(Optional.of("X")).when(connection).getSystemName(anyString(), anyString());
+
+        connection.shortIncludes("LIB1", "LIB1.T1,T2,LIB2.T3,LIB1.\"T4\"", false);
+
+        final InOrder order = inOrder(connection);
+        order.verify(connection).getAllSystemNames("LIB1", List.of("T1", "T2", "T4"));
+        order.verify(connection).getAllSystemNames("LIB2", List.of("T3"));
+        order.verify(connection).getTableType("LIB1", "T1");
+    }
+
+    @Test
+    void a_failed_prefetch_falls_back_to_the_per_table_lookups() throws Exception {
+        doThrow(new SQLException("catalog unavailable")).when(connection).getAllSystemNames(anyString(), any());
+        doReturn("T").when(connection).getTableType("LIB1", "T1");
+        doReturn(Optional.of("T1")).when(connection).getSystemName("LIB1", "T1");
+
+        assertThat(connection.shortIncludes("LIB1", "LIB1.T1", false)).containsExactly(new FileFilter("LIB1", "T1"));
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionSystemNamesTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionSystemNamesTest.java
@@ -15,17 +15,23 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.lang.reflect.Field;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.jdbc.JdbcConnection.BlockingResultSetConsumer;
@@ -38,6 +44,8 @@ import io.debezium.jdbc.JdbcConnection.StatementPreparer;
  * {@code table.include.list} - 462 and 722 rows for ~41 captured tables on the deployment in issue #50,
  * about 25s of round trips on every connector start.
  *
+ * <p>Since issue #71 the same query also carries the table type, for {@code shortIncludes} at task start.
+ *
  * <p>The query is executed through {@code prepareQueryWithBlockingConsumer}, which is stubbed here to
  * capture the statement text and the bound parameters; {@link As400JdbcConnection}'s constructor resolves
  * the real database name eagerly and would otherwise need a live AS400.
@@ -48,7 +56,18 @@ class As400JdbcConnectionSystemNamesTest {
     private final List<String> statements = new ArrayList<>();
     private final List<Map<Integer, String>> boundParameters = new ArrayList<>();
 
-    private void captureQueries() throws Exception {
+    /** {@code CALLS_REAL_METHODS} skips the constructor, so the cache maps are null. */
+    @BeforeEach
+    void giveTheMockItsCaches() throws Exception {
+        for (final String name : List.of("systemToLongTableName", "longToSystemTableName", "tableTypeByUpperName")) {
+            final Field field = As400JdbcConnection.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(connection, new HashMap<>());
+        }
+    }
+
+    /** Records the statement and its parameters, answering with the given {@code (system name, long name, type)} rows. */
+    private void captureQueries(String[]... rows) throws Exception {
         doAnswer(invocation -> {
             statements.add(invocation.getArgument(0));
             final Map<Integer, String> bound = new LinkedHashMap<>();
@@ -57,11 +76,18 @@ class As400JdbcConnectionSystemNamesTest {
                     .when(statement).setString(anyInt(), anyString());
             invocation.getArgument(1, StatementPreparer.class).accept(statement);
             boundParameters.add(bound);
-            // an empty result set: every mapping then resolves lazily, which is the documented fallback
-            final ResultSet resultSet = mock(ResultSet.class);
-            invocation.getArgument(2, BlockingResultSetConsumer.class).accept(resultSet);
+            invocation.getArgument(2, BlockingResultSetConsumer.class).accept(resultSetOf(rows));
             return connection;
         }).when(connection).prepareQueryWithBlockingConsumer(anyString(), any(), any());
+    }
+
+    private static ResultSet resultSetOf(String[]... rows) throws Exception {
+        final ResultSet resultSet = mock(ResultSet.class);
+        final Iterator<String[]> remaining = Arrays.asList(rows).iterator();
+        final String[][] current = { null };
+        doAnswer(next -> remaining.hasNext() && (current[0] = remaining.next()) != null).when(resultSet).next();
+        doAnswer(get -> current[0][get.getArgument(0, Integer.class) - 1]).when(resultSet).getString(anyInt());
+        return resultSet;
     }
 
     @Test
@@ -135,5 +161,32 @@ class As400JdbcConnectionSystemNamesTest {
 
         assertThat(statements.get(0)).contains("upper(table_name) in (?)");
         assertThat(boundParameters.get(0).values()).containsExactly("MYLIB", "ORDERS", "ORDERS");
+    }
+
+    @Test
+    void theTableTypeComesBackWithTheNamesAndAnswersTheTypeLookupWithoutARoundTrip() throws Exception {
+        captureQueries(new String[]{ "ORDERS", "ORDERS", "T" }, new String[]{ "\"Vue10002\"", "Vue1", "V" });
+
+        connection.getAllSystemNames("MYLIB", Set.of("ORDERS", "VUE1"));
+
+        assertThat(statements.get(0)).contains("trim(table_type)");
+        // by either name, in any case, as the per-table query matches
+        assertThat(connection.getTableType("mylib", "orders")).isEqualTo("T");
+        assertThat(connection.getTableType("MYLIB", "VUE10002")).isEqualTo("V");
+        assertThat(connection.getSystemName("MYLIB", "ORDERS")).isEqualTo(Optional.of("ORDERS"));
+        verify(connection, never()).prepareQueryAndMap(anyString(), any(), any());
+    }
+
+    /** The snapshot asks again after task start did; only what is still unresolved is queried, so a missing table is never cached as missing. */
+    @Test
+    void tablesAlreadyResolvedAreNotAskedAboutAgain() throws Exception {
+        captureQueries(new String[]{ "ORDERS", "ORDERS", "T" });
+        connection.getAllSystemNames("MYLIB", Set.of("ORDERS", "GONE"));
+
+        connection.getAllSystemNames("MYLIB", Set.of("ORDERS"));
+        connection.getAllSystemNames("MYLIB", Set.of("ORDERS", "GONE", "NEW"));
+
+        assertThat(statements).hasSize(2);
+        assertThat(boundParameters.get(1).values()).containsExactlyInAnyOrder("MYLIB", "GONE", "NEW", "GONE", "NEW");
     }
 }


### PR DESCRIPTION
Fixes #71.

## Problem

`As400JdbcConnection.shortIncludes()` resolved each entry of `table.include.list` with two serial `qsys2.systables` queries (`GET_TABLE_TYPE`, then `GET_SYSTEM_TABLE_NAME`), inside the window measured against `internal.task.management.timeout.ms`. On the source in the issue that is ~1.6 s per table against a budget growing 1 s per table, so past ~80 captured tables the task could never start and the connector crash-looped permanently.

## Change

- `GET_SYSTEM_TABLE_NAMES`, the batched query #62 added for the snapshot path, now also projects `table_type`. One round trip per schema yields the system name, long name and type for the whole include list.
- `shortIncludes()` parses all entries first, groups them by schema and calls `getAllSystemNames()` once per schema before the per-table loop. `classify()` and `getSystemName()` then answer from cache.
- `getTableType()` checks a new type cache first, keyed case-insensitively under both the long and the system name, matching how the per-table query already compares. The per-table queries stay in place as the fallback for whatever the prefetch did not return, so a failed or partial prefetch cannot drop a table.
- `getAllSystemNames()` skips tables an earlier call already resolved, so the snapshot's existing call at `As400SnapshotChangeEventSource.readTableStructure()` becomes a no-op. Tables that were missing are still asked about again, so nothing is cached as missing.

At 120 tables: ~240 serial catalog queries at task start become 1 per schema, plus one fallback query per table that genuinely does not exist.

## Verification

- Unit tests: connector module 91, journal-parsing 158, all green. Five tests added: prefetch runs once per schema before any per-table lookup with quotes stripped, a failed prefetch falls back, the type comes back with the names and answers `getTableType` without a round trip, and already-resolved tables are not re-queried.
- Live check against the IBM i test box: the extended query returned correct rows for a table named by its long name, one by its system name (`IT_SNAPSHOT` / `ITSNAPSHOT`) and one with a delimited system name (`"ibmi0001"`), in ~90 ms.

## Not done

`getJournalCacheDurationInMilliseconds()` is a single fixed round trip on the same path, not per table; left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
