### PR TITLE
Keep acknowledging the blocking-snapshot pause instead of parking (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,19 +120,27 @@ also supported via the signalling channel.
 
 An ad-hoc **blocking** snapshot is a cooperative handshake: the coordinator pauses streaming and waits
 for the streaming thread to acknowledge before the snapshot starts, then resumes it when the snapshot
-finishes. The streaming thread only reaches those handshake points between journal polls, so two wedges
-are possible while the connector still reports `live` (issue #27): a requested pause is never honored
-(the thread keeps draining a large shared-journal block), or a finished snapshot never resumes streaming
-(and later ad-hoc signals pile up). Two safeguards prevent this:
+finishes. The streaming thread only reaches those handshake points between journal polls, so three wedges
+are possible while the connector still reports `live`: a requested pause is never honored (the thread
+keeps draining a large shared-journal block, issue #27), a finished snapshot never resumes streaming
+(#27), or both sides sit on "paused" with no snapshot running at all (#74). Three safeguards prevent
+this:
 
 * The journal-drain loop breaks out as soon as a blocking-snapshot pause is requested, so the pause is
   honored within one journal entry rather than after a whole block.
-* `blocking.snapshot.pause.timeout.ms` (default `120000`) bounds how long the streaming thread's paused
-  view may stay out of sync with the coordinator (pause requested but not honored, or snapshot finished
-  but not resumed). Past that, the `WatchDog` fails the task with a retriable error and Debezium restarts
-  it (bounded by `errors.max.retries`), clearing the wedge instead of stalling silently — a loud, logged
-  restart rather than an in-place rescue, because interrupting the wedged thread cannot reliably resync
-  the handshake.
+* While paused, the streaming thread polls the coordinator's pause flag and re-acknowledges the pause
+  every 250 ms instead of parking on the coordinator's condition variable. Parking there deadlocks when
+  the orchestrator queues per-table backfills: the single-threaded blocking-snapshot executor starts the
+  next queued snapshot before the woken streaming thread can re-read the flag, so the thread parks again
+  while that snapshot waits forever for an acknowledgement it will never get. Re-acknowledging also means
+  a snapshot requested while streaming is already paused still runs, instead of being silently dropped.
+* `blocking.snapshot.pause.timeout.ms` (default `120000`) bounds how long the handshake may stay stuck in
+  any of the three states above — including "paused with no snapshot running", which is invisible to a
+  check that only compares the two views against each other. Past that, the `WatchDog` fails the task
+  with a retriable error and Debezium restarts it (bounded by `errors.max.retries`), clearing the wedge
+  instead of stalling silently — a loud, logged restart rather than an in-place rescue, because
+  interrupting the wedged thread cannot reliably resync the handshake. The snapshot itself is never
+  bounded by this timeout: a blocking snapshot may run for hours.
 
 > Not to be confused with a stale JDBC connection detected mid-snapshot, which is a connection-liveness
 > issue rather than offset/position recovery.

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
@@ -34,6 +34,11 @@ public class As400ChangeEventSourceFactory implements ChangeEventSourceFactory<A
     private final Clock clock;
     private final As400DatabaseSchema schema;
     private final SnapshotterService snapshotterService;
+    /**
+     * Shared by the snapshot and streaming sources: the streaming side's watchdog needs to know whether a
+     * snapshot is actually running to tell a legitimate blocking-snapshot pause from a wedged one (#74).
+     */
+    private final SnapshotActivity snapshotActivity = new SnapshotActivity();
 
     public As400ChangeEventSourceFactory(As400ConnectorConfig configuration, As400ConnectorConfig snapshotConfig,
                                          As400RpcConnection rpcConnection,
@@ -79,12 +84,12 @@ public class As400ChangeEventSourceFactory implements ChangeEventSourceFactory<A
                                                                                                       SnapshotProgressListener<As400Partition> snapshotProgressListener,
                                                                                                       NotificationService<As400Partition, As400OffsetContext> notificationService) {
         return new As400SnapshotChangeEventSource(snapshotConfig, rpcConnection, jdbcConnectionFactory, schema,
-                dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService);
+                dispatcher, clock, snapshotProgressListener, notificationService, snapshotterService, snapshotActivity);
     }
 
     @Override
     public StreamingChangeEventSource<As400Partition, As400OffsetContext> getStreamingChangeEventSource() {
         return new As400StreamingChangeEventSource(configuration, rpcConnection, jdbcConnectionFactory.mainConnection(),
-                dispatcher, errorHandler, clock, schema);
+                dispatcher, errorHandler, clock, schema, snapshotActivity);
     }
 }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -139,21 +139,22 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public static final long DEFAULT_BLOCKING_SNAPSHOT_PAUSE_TIMEOUT = 120000;
     /**
-     * How long (ms) the streaming thread's paused view may stay out of sync with the coordinator's
-     * ad-hoc blocking-snapshot pause before the {@link WatchDog} fails the task with a retriable error
-     * so it restarts. Guards the issue #27 wedges, where either a requested pause is never honored (the
-     * thread churns inside {@code getJournalEntries} over a large shared journal, refreshing the activity
-     * watchdog but never reaching the pause handshake, so the snapshot never starts) or a finished
-     * snapshot never resumes streaming. Should be comfortably larger than {@code max.journal.timeout}
-     * and than the worst-case time to process a single journal entry (including dispatching a large
-     * buffered transaction into a backpressured queue), since the pause handshake is only reached
-     * between entries.
+     * How long (ms) the ad-hoc blocking-snapshot handshake may stay stuck before the {@link WatchDog}
+     * fails the task with a retriable error so it restarts. Guards all three wedge directions: a
+     * requested pause that is never honored (the thread churns inside {@code getJournalEntries} over a
+     * large shared journal, refreshing the activity watchdog but never reaching the pause handshake, so
+     * the snapshot never starts, issue #27), a finished snapshot that never resumes streaming (#27), and
+     * streaming paused with no snapshot running at all (#74). Should be comfortably larger than
+     * {@code max.journal.timeout} and than the worst-case time to process a single journal entry
+     * (including dispatching a large buffered transaction into a backpressured queue), since the pause
+     * handshake is only reached between entries. It does not bound the snapshot itself: a blocking
+     * snapshot may run for hours without being treated as a wedge.
      */
     public static final Field BLOCKING_SNAPSHOT_PAUSE_TIMEOUT = Field.create("blocking.snapshot.pause.timeout.ms",
             "blocking snapshot pause timeout",
-            "Max time in ms the streaming thread may stay out of sync with a coordinator-requested ad-hoc "
-                    + "blocking-snapshot pause/resume before the task is failed with a retriable error (and "
-                    + "restarted) to avoid a silent wedge.",
+            "Max time in ms the ad-hoc blocking-snapshot pause handshake may stay stuck - a requested pause not "
+                    + "honored, a finished snapshot not resumed, or streaming paused with no snapshot running - "
+                    + "before the task is failed with a retriable error (and restarted) to avoid a silent wedge.",
             DEFAULT_BLOCKING_SNAPSHOT_PAUSE_TIMEOUT);
 
     public static final long DEFAULT_CACHE_ADDITIONAL_DELAY = 5000;

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -51,13 +51,14 @@ public class As400SnapshotChangeEventSource
     private final As400RpcConnection rpcConnection;
     private final As400DatabaseSchema schema;
     protected final SnapshotterService snapshotterService;
+    private final SnapshotActivity snapshotActivity;
 
     public As400SnapshotChangeEventSource(As400ConnectorConfig connectorConfig, As400RpcConnection rpcConnection,
                                           MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory,
                                           As400DatabaseSchema schema, EventDispatcher<As400Partition, TableId> dispatcher, Clock clock,
                                           SnapshotProgressListener<As400Partition> snapshotProgressListener,
                                           NotificationService<As400Partition, As400OffsetContext> notificationService,
-                                          SnapshotterService snapshotterService) {
+                                          SnapshotterService snapshotterService, SnapshotActivity snapshotActivity) {
 
         super(connectorConfig, jdbcConnectionFactory, schema, dispatcher, clock, snapshotProgressListener,
                 notificationService, snapshotterService);
@@ -67,14 +68,27 @@ public class As400SnapshotChangeEventSource
         this.jdbcConnection = jdbcConnectionFactory.mainConnection();
         this.schema = schema;
         this.snapshotterService = snapshotterService;
+        this.snapshotActivity = snapshotActivity;
     }
 
+    /**
+     * Publishes "a snapshot is running" for the whole duration of the snapshot, so the streaming side's
+     * {@link WatchDog} can tell a streaming thread legitimately paused for an ad-hoc blocking snapshot
+     * from one paused on a coordinator pause flag that leaked (issue #74). This has to span the whole
+     * call: the preparation phase before the first row is exported took nearly four minutes in the
+     * reported incident, and it is just as legitimate as the export itself.
+     */
     @Override
     public SnapshotResult<As400OffsetContext> execute(ChangeEventSourceContext context, As400Partition partition,
                                                       As400OffsetContext previousOffset, SnapshottingTask snapshottingTask)
             throws InterruptedException {
-
-        return super.execute(context, partition, previousOffset, snapshottingTask);
+        snapshotActivity.snapshotStarted();
+        try {
+            return super.execute(context, partition, previousOffset, snapshottingTask);
+        }
+        finally {
+            snapshotActivity.snapshotFinished();
+        }
     }
 
     /**

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -48,6 +48,10 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
     private static final int MAX_RETRIES = 20;
     /** Retry backoff grows from {@code poll.interval.ms} up to this multiple of it, then stays there. */
     private static final long MAX_RETRY_BACKOFF_MULTIPLIER = 8;
+    /** How often the paused streaming thread re-checks and re-acknowledges the blocking-snapshot pause. */
+    private static final long PAUSE_POLL_INTERVAL_MS = 250;
+    /** How often a still-paused streaming thread reports that it is waiting, so a pause is never silent. */
+    private static final long PAUSE_REPORT_INTERVAL_MS = 60_000;
 
     private static final Logger log = LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
 
@@ -73,11 +77,14 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
     private final Map<String, TransactionContext> txMap = new HashMap<>();
     private final Map<String, List<As400ChangeRecord>> bufferRecordMap = new HashMap<>();
     private final String database;
+    private final SnapshotActivity snapshotActivity;
     private As400OffsetContext offsetContext;
 
     public As400StreamingChangeEventSource(As400ConnectorConfig connectorConfig, As400RpcConnection dataConnection,
                                            As400JdbcConnection jdbcConnection, EventDispatcher<As400Partition, TableId> dispatcher,
-                                           ErrorHandler errorHandler, Clock clock, As400DatabaseSchema schema) {
+                                           ErrorHandler errorHandler, Clock clock, As400DatabaseSchema schema,
+                                           SnapshotActivity snapshotActivity) {
+        this.snapshotActivity = snapshotActivity;
         this.connectorConfig = connectorConfig;
         this.dataConnection = dataConnection;
         this.jdbcConnection = jdbcConnection;
@@ -123,27 +130,20 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
         int retries = 0;
         final WatchDog watchDog = new WatchDog(Thread.currentThread(), connectorConfig.getMaxRetrievalTimeout(),
                 connectorConfig.getBlockingSnapshotPauseTimeout(), context::isPaused,
-                errorHandler::setProducerThrowable);
+                snapshotActivity::isSnapshotRunning, errorHandler::setProducerThrowable);
         watchDog.start();
         try {
             while (context.isRunning()) {
                 // Cooperate with the coordinator when an ad-hoc blocking snapshot is requested:
-                // acknowledge the pause so the blocking snapshot can start, then wait for it to
-                // complete before resuming journal streaming. Without this the coordinator's
-                // blocking-snapshot thread waits forever on waitStreamingPaused() and the snapshot
-                // never runs. getJournalEntries() also checks isPaused() and returns promptly once a
-                // pause is requested (issue #27), so this handshake is reached within one journal entry
-                // rather than after a whole shared-journal block; if it is not reached at all the
-                // WatchDog fails the task with a retriable error so it restarts.
+                // acknowledge the pause so the blocking snapshot can start, then wait for it to complete
+                // before resuming journal streaming. Without this the coordinator's blocking-snapshot
+                // thread waits forever on waitStreamingPaused() and the snapshot never runs.
+                // getJournalEntries() also checks isPaused() and returns promptly once a pause is
+                // requested (issue #27), so this handshake is reached within one journal entry rather
+                // than after a whole shared-journal block; if it is not reached at all the WatchDog fails
+                // the task with a retriable error so it restarts.
                 if (context.isPaused()) {
-                    log.info("Streaming will now pause for an ad-hoc blocking snapshot");
-                    // The streaming thread parks in waitSnapshotCompletion() below and stops calling
-                    // watchDog.alive(); suspend the watchdog so it does not interrupt us mid-snapshot.
-                    watchDog.pause();
-                    context.streamingPaused();
-                    context.waitSnapshotCompletion();
-                    watchDog.resume();
-                    log.info("Streaming resumed after blocking snapshot");
+                    awaitBlockingSnapshots(context, watchDog);
                 }
                 try {
                     try {
@@ -207,6 +207,62 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
         finally {
             watchDog.stop();
         }
+    }
+
+    /**
+     * Parks journal streaming for as long as the coordinator keeps {@code context.isPaused()} set, i.e.
+     * for the whole run of ad-hoc blocking snapshots it dispatches back to back, re-acknowledging the
+     * pause on every tick.
+     * <p>
+     * The obvious implementation - acknowledge once with {@code streamingPaused()} and then park in
+     * {@code context.waitSnapshotCompletion()} - deadlocks with the coordinator (issue #74), and did so
+     * twice in one hour in production. {@code waitSnapshotCompletion()} loops on the coordinator's
+     * {@code paused} flag and only re-reads it after re-acquiring the coordinator's lock, which the
+     * resuming thread holds until it has signalled. The blocking-snapshot executor is single-threaded,
+     * so it goes straight from resuming one snapshot to starting the next queued one, and that next task
+     * sets {@code paused = true} (and {@code streaming = true}) again before the woken streaming thread
+     * gets the lock back. The streaming thread then sees "paused" once more and parks again - this time
+     * for good, because the acknowledgement it already sent was consumed by the previous snapshot and the
+     * new task is itself parked in {@code waitStreamingPaused()} waiting for an acknowledgement that can
+     * no longer come. Both sides read "paused" forever, no snapshot runs, streaming never resumes, and
+     * nothing fails: the connector freezes while every health probe stays green.
+     * <p>
+     * Polling the flag instead of parking on the condition breaks that: the pause is acknowledged again
+     * on every tick, so a snapshot task that started while we were already paused gets its handshake and
+     * runs, and the acknowledgement can no longer be lost to a race. The cost is one lock acquisition and
+     * a {@code signalAll()} with no waiters every {@value #PAUSE_POLL_INTERVAL_MS} ms while paused, and up
+     * to that much added latency before streaming resumes - negligible next to a snapshot.
+     * <p>
+     * The pause is not bounded here: a legitimate blocking snapshot can run for hours, so a timeout on
+     * this loop would abort real work. The {@link WatchDog} bounds it instead, using "a snapshot is
+     * running" to tell a healthy pause from a wedged one.
+     */
+    private void awaitBlockingSnapshots(ChangeEventSourceContext context, WatchDog watchDog) throws InterruptedException {
+        log.info("Streaming will now pause for an ad-hoc blocking snapshot");
+        // The streaming thread stops calling watchDog.alive() while parked here; suspend the activity
+        // invariant so it does not interrupt us mid-snapshot. The handshake invariant keeps running.
+        watchDog.pause();
+        final long pausedAt = System.currentTimeMillis();
+        long nextReport = pausedAt + PAUSE_REPORT_INTERVAL_MS;
+        try {
+            while (context.isRunning() && context.isPaused()) {
+                // (re-)acknowledge the pause: this is what a coordinator task parked in
+                // waitStreamingPaused() is waiting for, whether it asked before or after we paused
+                context.streamingPaused();
+                final long now = System.currentTimeMillis();
+                if (now >= nextReport) {
+                    // a multi-hour pause would otherwise be indistinguishable from a freeze in the logs
+                    log.info("Still paused for an ad-hoc blocking snapshot after {}s (snapshot running: {})",
+                            (now - pausedAt) / 1000, snapshotActivity.isSnapshotRunning());
+                    nextReport = now + PAUSE_REPORT_INTERVAL_MS;
+                }
+                Thread.sleep(PAUSE_POLL_INTERVAL_MS);
+            }
+        }
+        finally {
+            watchDog.resume();
+        }
+        log.info("Streaming resumed after blocking snapshot, paused for {}ms", System.currentTimeMillis() - pausedAt);
     }
 
     /**

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SnapshotActivity.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SnapshotActivity.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Task-scoped, thread-safe view of "a snapshot is currently running", shared by
+ * {@link As400SnapshotChangeEventSource} (which publishes it) and the streaming side's
+ * {@link WatchDog} (which consumes it).
+ * <p>
+ * The streaming thread pauses for an ad-hoc blocking snapshot on the coordinator's request, and both
+ * sides of that handshake then legitimately read "paused" for as long as the snapshot takes - which
+ * can be hours. That makes elapsed time alone useless for telling a running snapshot apart from a
+ * wedged handshake (issue #74), so the watchdog needs this second signal: paused with no snapshot
+ * running is never legitimate for long.
+ * <p>
+ * A counter rather than a flag, so overlapping snapshots (a blocking snapshot requested while
+ * another snapshot is still finishing) cannot clear the signal early.
+ */
+public class SnapshotActivity {
+
+    private final AtomicInteger running = new AtomicInteger();
+
+    public void snapshotStarted() {
+        running.incrementAndGet();
+    }
+
+    public void snapshotFinished() {
+        running.decrementAndGet();
+    }
+
+    public boolean isSnapshotRunning() {
+        return running.get() > 0;
+    }
+}

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/WatchDog.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/WatchDog.java
@@ -24,17 +24,23 @@ import org.slf4j.LoggerFactory;
  * {@code wait} ms, otherwise the streaming thread is interrupted. This unsticks interruptible
  * waits (a full queue, a metronome pause); blocked socket reads are bounded separately by the
  * connection's SO_TIMEOUT. Original behaviour, unchanged.</li>
- * <li><b>Blocking-snapshot handshake convergence (issue #27).</b> An ad-hoc blocking snapshot is a
+ * <li><b>Blocking-snapshot handshake liveness (issues #27, #74).</b> An ad-hoc blocking snapshot is a
  * cooperative handshake: the coordinator flips {@code context.isPaused()}, the streaming thread must
- * acknowledge by pausing, and resume once the coordinator flips it back. The streaming thread's view
- * ({@link #pause()}/{@link #resume()}) staying out of sync with the coordinator's for more than
- * {@code pauseTimeout} ms means the handshake is wedged — a requested pause was never honored, or a
- * finished snapshot never resumed streaming — while the connector still reports live. No in-place
- * rescue is attempted: an interrupt cannot reliably resync the handshake (it does not unblock jt400
- * socket I/O, and where it lands it terminates the streaming loop anyway) and cannot unstick the
- * coordinator-side waits at all. Instead the task is failed with an {@link IOException}, which
- * Debezium's {@code ErrorHandler} classifies as retriable, so the task restarts itself (bounded by
- * {@code errors.max.retries}) — the one remedy that clears both wedge directions.</li>
+ * acknowledge by pausing, and resume once the coordinator flips it back. Three states are wedges:
+ * <ul>
+ * <li>the coordinator asked for a pause the streaming thread has not honored,</li>
+ * <li>the coordinator resumed but the streaming thread is still paused,</li>
+ * <li>both sides agree on "paused" while no snapshot is running - the direction that made issue #74
+ * invisible, since a stale pause flag looks exactly like a healthy pause to a checker that only
+ * compares the two views against each other.</li>
+ * </ul>
+ * Any of them lasting longer than {@code pauseTimeout} means the connector has stopped streaming
+ * while still reporting live. No in-place rescue is attempted: an interrupt cannot reliably resync
+ * the handshake (it does not unblock jt400 socket I/O, and where it lands it terminates the
+ * streaming loop anyway) and cannot unstick the coordinator-side waits at all. Instead the task is
+ * failed with an {@link IOException}, which Debezium's {@code ErrorHandler} classifies as retriable,
+ * so the task restarts itself (bounded by {@code errors.max.retries}) - the one remedy that clears
+ * every wedge direction.</li>
  * </ol>
  */
 public class WatchDog {
@@ -44,30 +50,36 @@ public class WatchDog {
     private final long wait;
     private final long pauseTimeout;
     private final BooleanSupplier pausePending;
+    private final BooleanSupplier snapshotRunning;
     private final Consumer<Throwable> onWedged;
 
     private volatile long lastSeen = System.currentTimeMillis();
     private volatile boolean paused = false;
     // handshake state, touched only by the single scheduled checker thread
-    private long desyncSince = 0;
+    private long wedgedSince = 0;
     private boolean wedgeReported = false;
     private ScheduledExecutorService executor;
 
     /**
-     * @param notify       the streaming thread to interrupt when journal activity stalls
-     * @param wait         staleness threshold for {@link #alive()} (ms)
-     * @param pauseTimeout how long the streaming thread's paused view may stay out of sync with the
-     *                     coordinator's blocking-snapshot pause before the task is failed (ms)
-     * @param pausePending the coordinator's view of the blocking-snapshot pause, typically
-     *                     {@code context::isPaused}
-     * @param onWedged     invoked with a retriable exception when the handshake is wedged; typically
-     *                     the connector's {@code ErrorHandler::setProducerThrowable}
+     * @param notify          the streaming thread to interrupt when journal activity stalls
+     * @param wait            staleness threshold for {@link #alive()} (ms)
+     * @param pauseTimeout    how long the blocking-snapshot handshake may stay in a state that is not
+     *                        making progress before the task is failed (ms)
+     * @param pausePending    the coordinator's view of the blocking-snapshot pause, typically
+     *                        {@code context::isPaused}
+     * @param snapshotRunning whether a snapshot is currently running, typically
+     *                        {@code snapshotActivity::isSnapshotRunning}; the pause is only legitimate
+     *                        while this is true
+     * @param onWedged        invoked with a retriable exception when the handshake is wedged; typically
+     *                        the connector's {@code ErrorHandler::setProducerThrowable}
      */
-    public WatchDog(Thread notify, long wait, long pauseTimeout, BooleanSupplier pausePending, Consumer<Throwable> onWedged) {
+    public WatchDog(Thread notify, long wait, long pauseTimeout, BooleanSupplier pausePending, BooleanSupplier snapshotRunning,
+                    Consumer<Throwable> onWedged) {
         this.notify = notify;
         this.wait = wait;
         this.pauseTimeout = pauseTimeout;
         this.pausePending = pausePending;
+        this.snapshotRunning = snapshotRunning;
         this.onWedged = onWedged;
     }
 
@@ -102,38 +114,54 @@ public class WatchDog {
     private void doCheck() {
         final long now = System.currentTimeMillis();
         // invariant 1: journal activity while streaming. Also applies while a pause is pending but not
-        // yet honored — unsticking a stalled thread lets it reach the pause handshake.
+        // yet honored - unsticking a stalled thread lets it reach the pause handshake.
         if (!paused && now - lastSeen > wait) {
             log.warn("No update since {} interrupting streaming thread {}", new Date(lastSeen), notify.getName());
             // grant a full window before interrupting again, whatever the tick
             lastSeen = now;
             notify.interrupt();
         }
-        // invariant 2: the paused view must converge with the coordinator within pauseTimeout. A
-        // short-lived mismatch is normal (the handshake is reached between journal entries); only a
-        // persistent one is a wedge.
-        final boolean coordinatorPaused = pausePending.getAsBoolean();
-        if (paused == coordinatorPaused) {
-            desyncSince = 0;
+        // invariant 2: the handshake must keep making progress. Every state below is transient in a
+        // healthy connector (a pause is acknowledged between journal entries, a snapshot starts right
+        // after the acknowledgement); only one that persists past pauseTimeout is a wedge.
+        final String direction = wedgeDirection();
+        if (direction == null) {
+            wedgedSince = 0;
             wedgeReported = false;
             return;
         }
-        if (desyncSince == 0) {
-            desyncSince = now;
+        if (wedgedSince == 0) {
+            wedgedSince = now;
             return;
         }
-        if (!wedgeReported && now - desyncSince > pauseTimeout) {
+        if (!wedgeReported && now - wedgedSince > pauseTimeout) {
             wedgeReported = true;
-            final String direction = coordinatorPaused
-                    ? "pause requested but streaming thread has not paused"
-                    : "blocking snapshot finished but streaming thread has not resumed";
             log.error("Blocking-snapshot handshake wedged for {}ms ({}); failing the task so it restarts "
-                    + "instead of stalling silently while reporting live (thread {}, issue #27)",
-                    now - desyncSince, direction, notify.getName());
+                    + "instead of stalling silently while reporting live (thread {}, issues #27/#74)",
+                    now - wedgedSince, direction, notify.getName());
             // IOException is classified retriable by Debezium's ErrorHandler: the task restarts itself
             onWedged.accept(new IOException(
-                    "Blocking-snapshot handshake wedged: " + direction + " for over " + pauseTimeout + "ms (issue #27)"));
+                    "Blocking-snapshot handshake wedged: " + direction + " for over " + pauseTimeout + "ms (issues #27/#74)"));
         }
+    }
+
+    /**
+     * @return a description of the handshake state the streaming thread is stuck in, or {@code null}
+     *         when the handshake is in a state it can legitimately stay in
+     */
+    private String wedgeDirection() {
+        final boolean coordinatorPaused = pausePending.getAsBoolean();
+        if (paused != coordinatorPaused) {
+            return coordinatorPaused
+                    ? "pause requested but streaming thread has not paused"
+                    : "blocking snapshot finished but streaming thread has not resumed";
+        }
+        if (paused && !snapshotRunning.getAsBoolean()) {
+            // issue #74: the coordinator's pause flag leaked. Both views read "paused" forever, so
+            // comparing them detects nothing; only "nothing is being snapshotted" gives it away.
+            return "streaming paused but no snapshot is running";
+        }
+        return null;
     }
 
     public void alive() {

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceMemberlessTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceMemberlessTest.java
@@ -55,7 +55,7 @@ public class As400SnapshotChangeEventSourceMemberlessTest {
         return new As400SnapshotChangeEventSource(new As400ConnectorConfig(builder.build()),
                 mock(As400RpcConnection.class), factory, mock(As400DatabaseSchema.class),
                 mock(EventDispatcher.class), Clock.SYSTEM, mock(SnapshotProgressListener.class),
-                mock(NotificationService.class), mock(SnapshotterService.class));
+                mock(NotificationService.class), mock(SnapshotterService.class), new SnapshotActivity());
     }
 
     private void discovered(TableId... tables) throws SQLException {

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceHeartbeatTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceHeartbeatTest.java
@@ -179,7 +179,8 @@ public class As400StreamingChangeEventSourceHeartbeatTest {
                 positionAt(BLOCK_START.subtract(BigInteger.ONE), true));
 
         final As400StreamingChangeEventSource source = new As400StreamingChangeEventSource(config,
-                dataConnection(state), jdbcConnection(), dispatcher, mock(ErrorHandler.class), Clock.SYSTEM, schema);
+                dataConnection(state), jdbcConnection(), dispatcher, mock(ErrorHandler.class), Clock.SYSTEM, schema,
+                new SnapshotActivity());
 
         source.execute(new SingleIterationContext(), new As400Partition(config.getLogicalName()), offsetContext);
         return offsetContext;

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourcePauseTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourcePauseTest.java
@@ -7,27 +7,40 @@ package io.debezium.connector.db2as400;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
-import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
 /**
  * Verifies that {@link As400StreamingChangeEventSource} cooperates with the coordinator's ad-hoc
- * blocking-snapshot pause handshake, and that it suspends the {@link WatchDog} for the duration of
- * the snapshot so the parked streaming thread is not interrupted.
+ * blocking-snapshot pause handshake: that it suspends the {@link WatchDog} for the duration of the
+ * snapshot so the parked streaming thread is not interrupted, and that it keeps acknowledging the pause
+ * so back-to-back blocking snapshots cannot deadlock it (issue #74).
  */
 public class As400StreamingChangeEventSourcePauseTest {
 
@@ -36,24 +49,20 @@ public class As400StreamingChangeEventSourcePauseTest {
     private static final long SNAPSHOT_DURATION_MS = 300;
 
     /**
-     * Fake context that requests a pause on the first streaming iteration and simulates a snapshot
-     * that runs longer than the watchdog timeout. Mirrors the real coordinator's {@code isPaused()},
-     * which is a stable flag: true from when the blocking snapshot is requested until it completes and
-     * streaming is resumed. The watchdog polls this flag, so a one-shot fake would look like a
-     * "snapshot finished but not resumed" desync.
+     * Fake context that requests a pause on the first streaming iteration and simulates a snapshot that
+     * runs longer than the watchdog timeout. Mirrors the real coordinator's {@code isPaused()}, which is
+     * a stable flag: true from when the blocking snapshot is requested until it completes and streaming
+     * is resumed.
      */
     private static final class PausingContext implements ChangeEventSourceContext {
-        private final AtomicInteger runningChecks = new AtomicInteger();
         // paused for the whole simulated snapshot; cleared when the snapshot "resumes" streaming
         private volatile boolean paused = true;
-        boolean streamingPausedCalled = false;
-        boolean waitSnapshotCompletionCalled = false;
-        boolean interruptedDuringSnapshot = false;
+        final AtomicInteger acknowledgements = new AtomicInteger();
 
         @Override
         public boolean isRunning() {
-            // allow exactly one streaming iteration, then stop the loop
-            return runningChecks.getAndIncrement() == 0;
+            // stay running while paused, then end the streaming loop after the first journal poll
+            return paused;
         }
 
         @Override
@@ -63,23 +72,12 @@ public class As400StreamingChangeEventSourcePauseTest {
 
         @Override
         public void streamingPaused() {
-            streamingPausedCalled = true;
+            acknowledgements.incrementAndGet();
         }
 
         @Override
-        public void waitSnapshotCompletion() throws InterruptedException {
-            waitSnapshotCompletionCalled = true;
-            try {
-                // stand in for a long blocking snapshot; without WatchDog.pause() the streaming
-                // thread would be interrupted here and the snapshot would be aborted
-                Thread.sleep(SNAPSHOT_DURATION_MS);
-                // the coordinator clears the pause when the snapshot completes, before waking the thread
-                paused = false;
-            }
-            catch (InterruptedException e) {
-                interruptedDuringSnapshot = true;
-                throw e;
-            }
+        public void waitSnapshotCompletion() {
+            throw new AssertionError("the streaming thread must not park on the coordinator's condition (issue #74)");
         }
 
         @Override
@@ -92,39 +90,241 @@ public class As400StreamingChangeEventSourcePauseTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void blockingSnapshotPausesStreamingWithoutWatchdogInterruption() throws Exception {
+        final As400RpcConnection dataConnection = dataConnection();
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final As400StreamingChangeEventSource source = source(dataConnection, errorHandler, new SnapshotActivity());
+
+        final PausingContext context = new PausingContext();
+        final ExecutorService snapshotThread = Executors.newSingleThreadExecutor();
+        try {
+            // stand in for a blocking snapshot that outlasts the watchdog timeout: without WatchDog.pause()
+            // the streaming thread would be interrupted while parked and the snapshot would be aborted
+            snapshotThread.submit(() -> {
+                Thread.sleep(SNAPSHOT_DURATION_MS);
+                context.paused = false;
+                return null;
+            });
+
+            source.execute(context, new As400Partition("server"), mock(As400OffsetContext.class));
+        }
+        finally {
+            snapshotThread.shutdownNow();
+        }
+
+        // the handshake happened: streaming acknowledged the pause
+        assertThat(context.acknowledgements.get()).isPositive();
+        // the watchdog did not interrupt the parked streaming thread mid-snapshot
+        assertThat(Thread.interrupted()).isFalse();
+        // streaming actually resumed afterwards (the journal was polled once after the pause)
+        verify(dataConnection, times(1)).getJournalEntries(any(), any(), any(), any());
+        verify(errorHandler, never()).setProducerThrowable(any());
+    }
+
+    /**
+     * Regression test for issue #74. Reproduces the coordinator's handshake field for field
+     * ({@code ChangeEventSourceCoordinator.ChangeEventSourceContextImpl}, 3.5.0.Final) and runs two
+     * blocking snapshots back to back on a single thread, as the coordinator's single-threaded
+     * {@code blockingSnapshotExecutor} does when the orchestrator queues a per-table backfill.
+     * <p>
+     * With the streaming thread parked in {@code waitSnapshotCompletion()} this deadlocked: the second
+     * task re-set {@code paused} before the woken streaming thread could re-read it, so the thread parked
+     * again while the task waited for an acknowledgement it would never send. Both sides then read
+     * "paused" forever, the second snapshot never ran, and the connector froze while reporting live.
+     */
+    @Test
+    @Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    public void queuedBlockingSnapshotsAllRunAndStreamingResumes() throws Exception {
+        final FakeCoordinator coordinator = new FakeCoordinator();
+        final SnapshotActivity snapshotActivity = new SnapshotActivity();
+        final As400RpcConnection dataConnection = dataConnection();
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final As400StreamingChangeEventSource source = source(dataConnection, errorHandler, snapshotActivity);
+
+        // the first request is already pending when streaming reaches the handshake, as in the incident
+        coordinator.beginSnapshot();
+
+        final ExecutorService blockingSnapshotExecutor = Executors.newSingleThreadExecutor();
+        try {
+            final Future<?> snapshots = blockingSnapshotExecutor.submit(
+                    () -> coordinator.runQueuedSnapshots(snapshotActivity, "TABLE_1", "TABLE_2"));
+
+            source.execute(coordinator, new As400Partition("server"), mock(As400OffsetContext.class));
+
+            // surfaces a handshake that never completed on the coordinator side
+            snapshots.get(30, TimeUnit.SECONDS);
+        }
+        finally {
+            blockingSnapshotExecutor.shutdownNow();
+        }
+
+        // both queued snapshots ran: the second one's pause was acknowledged even though the streaming
+        // thread was already paused when it was requested
+        assertThat(coordinator.snapshotsRun).containsExactly("TABLE_1", "TABLE_2");
+        // the pause is re-acknowledged while it lasts, which is what unwedges the second request
+        assertThat(coordinator.acknowledgements.get()).isGreaterThan(1);
+        // streaming resumed once the last snapshot finished
+        verify(dataConnection, atLeastOnce()).getJournalEntries(any(), any(), any(), any());
+        // no wedge was reported: the handshake completed on its own
+        verify(errorHandler, never()).setProducerThrowable(any());
+    }
+
+    /**
+     * The coordinator's blocking-snapshot handshake, copied from
+     * {@code ChangeEventSourceCoordinator} (3.5.0.Final) so the connector is tested against the real
+     * locking, and driven by a single thread like the real {@code blockingSnapshotExecutor}.
+     */
+    private static final class FakeCoordinator implements ChangeEventSourceContext {
+
+        private final Lock lock = new ReentrantLock();
+        private final Condition snapshotFinished = lock.newCondition();
+        private final Condition streamingPausedCondition = lock.newCondition();
+
+        // one journal poll once the last snapshot has resumed streaming, then the streaming loop ends
+        private final AtomicInteger pollsAfterResume = new AtomicInteger(1);
+        private volatile boolean paused = false;
+        private volatile boolean streaming = false;
+
+        final List<String> snapshotsRun = Collections.synchronizedList(new ArrayList<>());
+        final AtomicInteger acknowledgements = new AtomicInteger();
+
+        @Override
+        public boolean isRunning() {
+            return paused || pollsAfterResume.getAndDecrement() > 0;
+        }
+
+        @Override
+        public boolean isPaused() {
+            return paused;
+        }
+
+        @Override
+        public void resumeStreaming() {
+            lock.lock();
+            try {
+                snapshotFinished.signalAll();
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void waitSnapshotCompletion() throws InterruptedException {
+            lock.lock();
+            try {
+                while (paused) {
+                    snapshotFinished.await();
+                    streaming = true;
+                }
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void streamingPaused() {
+            lock.lock();
+            try {
+                streaming = false;
+                acknowledgements.incrementAndGet();
+                streamingPausedCondition.signalAll();
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void waitStreamingPaused() throws InterruptedException {
+            lock.lock();
+            try {
+                long remaining = TimeUnit.SECONDS.toNanos(20);
+                while (streaming) {
+                    if (remaining <= 0) {
+                        throw new AssertionError("the streaming thread never acknowledged the pause: handshake wedged");
+                    }
+                    remaining = streamingPausedCondition.awaitNanos(remaining);
+                }
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+
+        /** {@code doBlockingSnapshot}: request the pause and wait for the streaming thread to honor it. */
+        void beginSnapshot() {
+            lock.lock();
+            try {
+                paused = true;
+                streaming = true;
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+
+        Void runQueuedSnapshots(SnapshotActivity snapshotActivity, String... tables) throws InterruptedException {
+            for (int i = 0; i < tables.length; i++) {
+                beginSnapshot(); // a no-op for the chained requests, which were begun by endSnapshot below
+                waitStreamingPaused();
+
+                snapshotActivity.snapshotStarted();
+                try {
+                    Thread.sleep(50);
+                    snapshotsRun.add(tables[i]);
+                }
+                finally {
+                    snapshotActivity.snapshotFinished();
+                }
+
+                endSnapshot(i + 1 < tables.length);
+            }
+            return null;
+        }
+
+        /** {@code resumeStreaming}, immediately followed by the next queued request if there is one. */
+        void endSnapshot(boolean anotherQueued) {
+            lock.lock();
+            try {
+                paused = false;
+                snapshotFinished.signalAll();
+                // The woken streaming thread cannot re-read `paused` until it re-acquires this lock, and
+                // the single-threaded executor is free to start the next queued request before then. That
+                // interleaving is what wedged production; pinning it here makes the test deterministic.
+                if (anotherQueued) {
+                    paused = true;
+                    streaming = true;
+                }
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private As400RpcConnection dataConnection() throws Exception {
+        final As400RpcConnection dataConnection = mock(As400RpcConnection.class);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any())).thenReturn(RetrievalState.Success);
+        return dataConnection;
+    }
+
+    @SuppressWarnings("unchecked")
+    private As400StreamingChangeEventSource source(As400RpcConnection dataConnection, ErrorHandler errorHandler,
+                                                   SnapshotActivity snapshotActivity) {
         final As400ConnectorConfig config = mock(As400ConnectorConfig.class);
         when(config.getPollInterval()).thenReturn(Duration.ofMillis(1));
         when(config.getMaxRetrievalTimeout()).thenReturn(WATCHDOG_TIMEOUT_MS);
-        // comfortably longer than the simulated snapshot so the pause is never treated as a wedge
-        when(config.getBlockingSnapshotPauseTimeout()).thenReturn(10_000L);
+        // comfortably longer than the simulated snapshots so no pause is treated as a wedge
+        when(config.getBlockingSnapshotPauseTimeout()).thenReturn(30_000L);
 
         final As400JdbcConnection jdbcConnection = mock(As400JdbcConnection.class);
         when(jdbcConnection.getRealDatabaseName()).thenReturn("DB");
 
-        final As400RpcConnection dataConnection = mock(As400RpcConnection.class);
-        when(dataConnection.getJournalEntries(any(), any(), any(), any())).thenReturn(RetrievalState.Success);
-
-        final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
-        final As400DatabaseSchema schema = mock(As400DatabaseSchema.class);
-        final ErrorHandler errorHandler = mock(ErrorHandler.class);
-
-        final As400StreamingChangeEventSource source = new As400StreamingChangeEventSource(
-                config, dataConnection, jdbcConnection, dispatcher, errorHandler, Clock.SYSTEM, schema);
-
-        final PausingContext context = new PausingContext();
-        final As400Partition partition = new As400Partition("server");
-        final As400OffsetContext offsetContext = mock(As400OffsetContext.class);
-
-        source.execute(context, partition, offsetContext);
-
-        // the handshake happened: streaming acknowledged the pause and waited for the snapshot
-        assertThat(context.streamingPausedCalled).isTrue();
-        assertThat(context.waitSnapshotCompletionCalled).isTrue();
-        // the watchdog did not interrupt the parked streaming thread mid-snapshot
-        assertThat(context.interruptedDuringSnapshot).isFalse();
-        // streaming actually resumed afterwards (the journal was polled once after the pause)
-        verify(dataConnection, times(1)).getJournalEntries(any(), any(), any(), any());
+        return new As400StreamingChangeEventSource(config, dataConnection, jdbcConnection,
+                mock(EventDispatcher.class), errorHandler, Clock.SYSTEM, mock(As400DatabaseSchema.class),
+                snapshotActivity);
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRecoveryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRecoveryTest.java
@@ -99,7 +99,7 @@ class As400StreamingChangeEventSourceRecoveryTest {
         @SuppressWarnings("unchecked")
         final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
         return new As400StreamingChangeEventSource(config, dataConnection, jdbcConnection, dispatcher,
-                mock(ErrorHandler.class), Clock.SYSTEM, mock(As400DatabaseSchema.class));
+                mock(ErrorHandler.class), Clock.SYSTEM, mock(As400DatabaseSchema.class), new SnapshotActivity());
     }
 
     private void execute(As400StreamingChangeEventSource source, int iterations) throws InterruptedException {

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRetryBackoffTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRetryBackoffTest.java
@@ -103,7 +103,7 @@ class As400StreamingChangeEventSourceRetryBackoffTest {
         @SuppressWarnings("unchecked")
         final EventDispatcher<As400Partition, TableId> dispatcher = mock(EventDispatcher.class);
         return new As400StreamingChangeEventSource(config, dataConnection, jdbcConnection, dispatcher,
-                mock(ErrorHandler.class), Clock.SYSTEM, mock(As400DatabaseSchema.class));
+                mock(ErrorHandler.class), Clock.SYSTEM, mock(As400DatabaseSchema.class), new SnapshotActivity());
     }
 
     @Test

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/WatchDogTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/WatchDogTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.db2as400;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test;
 public class WatchDogTest {
     private WatchDog createTestSubject() {
         // no pause ever pending: exercises the original activity-timeout behaviour only
-        return new WatchDog(Thread.currentThread(), 10, 10_000, () -> false, t -> {
+        return new WatchDog(Thread.currentThread(), 10, 10_000, () -> false, () -> false, t -> {
         });
     }
 
@@ -96,7 +97,7 @@ public class WatchDogTest {
     public void testUnhonoredPauseFailsTask() throws Exception {
         final AtomicReference<Throwable> wedged = new AtomicReference<>();
         // long activity timeout so failure mode 1 cannot fire; short pause timeout is what we test
-        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> true, wedged::set);
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> true, () -> false, wedged::set);
         testSubject.start();
         Exception thrown = null;
         try {
@@ -126,7 +127,7 @@ public class WatchDogTest {
     public void testStuckResumeFailsTask() throws Exception {
         final AtomicReference<Throwable> wedged = new AtomicReference<>();
         // coordinator is no longer paused, but the streaming thread still believes it is paused
-        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> false, wedged::set);
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> false, () -> false, wedged::set);
         testSubject.pause();
         testSubject.start();
         Exception thrown = null;
@@ -145,12 +146,13 @@ public class WatchDogTest {
 
     /**
      * The pause handshake normally completes between journal entries: a mismatch that resolves within
-     * pauseTimeout is not a wedge and must not fail the task.
+     * pauseTimeout is not a wedge and must not fail the task. Once the pause is honored a snapshot runs,
+     * for as long as it takes, and that must not be failed either.
      */
     @Test
     public void testPauseHonoredWithinTimeoutIsNotAWedge() throws Exception {
         final AtomicReference<Throwable> wedged = new AtomicReference<>();
-        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 200, () -> true, wedged::set);
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 200, () -> true, () -> true, wedged::set);
         testSubject.start();
         try {
             // honor the pending pause well before the timeout, then linger past several check ticks
@@ -163,5 +165,77 @@ public class WatchDogTest {
         }
         Assertions.assertThat(wedged.get()).isNull();
         Assertions.assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    /**
+     * Issue #74 (third wedge): the coordinator's pause flag leaked, so both views agree on "paused"
+     * forever with no snapshot running. Comparing the two views detects nothing - only the absence of a
+     * running snapshot gives it away - and the activity invariant is suspended while paused, so without
+     * this check the connector freezes silently and permanently.
+     */
+    @Test
+    public void testPausedWithNoSnapshotRunningFailsTask() throws Exception {
+        final AtomicReference<Throwable> wedged = new AtomicReference<>();
+        // both views paused, nothing snapshotting: the state the connector froze in
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> true, () -> false, wedged::set);
+        testSubject.pause();
+        testSubject.start();
+        Exception thrown = null;
+        try {
+            Thread.sleep(400);
+        }
+        catch (final Exception e) {
+            thrown = e;
+        }
+        finally {
+            testSubject.stop();
+        }
+        Assertions.assertThat(thrown).isNull();
+        Assertions.assertThat(wedged.get()).isInstanceOf(java.io.IOException.class);
+        Assertions.assertThat(wedged.get()).hasMessageContaining("no snapshot is running");
+    }
+
+    /**
+     * A blocking snapshot may legitimately run for hours with both views paused the whole time, so the
+     * paused state itself must never be bounded by elapsed time alone.
+     */
+    @Test
+    public void testLongRunningSnapshotIsNotAWedge() throws Exception {
+        final AtomicReference<Throwable> wedged = new AtomicReference<>();
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 30, () -> true, () -> true, wedged::set);
+        testSubject.pause();
+        testSubject.start();
+        try {
+            // many times the pause timeout: a time-based cap on the pause would have fired long ago
+            Thread.sleep(400);
+        }
+        finally {
+            testSubject.stop();
+        }
+        Assertions.assertThat(wedged.get()).isNull();
+        Assertions.assertThat(Thread.currentThread().isInterrupted()).isFalse();
+    }
+
+    /**
+     * The snapshot only starts once the pause has been acknowledged, so "paused with no snapshot
+     * running" is normal for a moment and must not be reported before the timeout elapses.
+     */
+    @Test
+    public void testSnapshotStartingUpIsNotAWedge() throws Exception {
+        final AtomicReference<Throwable> wedged = new AtomicReference<>();
+        final AtomicBoolean snapshotRunning = new AtomicBoolean(false);
+        final WatchDog testSubject = new WatchDog(Thread.currentThread(), 10_000, 200, () -> true, snapshotRunning::get, wedged::set);
+        testSubject.pause();
+        testSubject.start();
+        try {
+            // the snapshot gets going well within the timeout, then runs past several check ticks
+            Thread.sleep(50);
+            snapshotRunning.set(true);
+            Thread.sleep(500);
+        }
+        finally {
+            testSubject.stop();
+        }
+        Assertions.assertThat(wedged.get()).isNull();
     }
 }


### PR DESCRIPTION
Fixes #74.

## What was actually broken

Not a watchdog blind spot with an unknown leak behind it — the leak is a **deadlock between the streaming thread and Debezium's `ChangeEventSourceCoordinator`**, and it is fully explained by the upstream code (3.5.0.Final, verified against the artifact we build against):

1. The streaming thread acknowledged the pause once (`context.streamingPaused()`) and then parked in `context.waitSnapshotCompletion()`, which loops on the coordinator's `paused` flag and can only re-read it **after re-acquiring the coordinator's lock** — held by the resuming thread until it has signalled.
2. `blockingSnapshotExecutor` is single-threaded, so it goes straight from `resumeStreaming()` of one snapshot to the next queued task, which sets `paused = true` and `streaming = true` again — before the woken streaming thread gets the lock back.
3. The streaming thread re-checks, sees `paused == true`, and parks again. This time for good: the acknowledgement it sent was consumed by the *previous* snapshot, and the new task is itself parked in `waitStreamingPaused()` waiting for an acknowledgement that can never come.

Both sides then read "paused" forever with no snapshot running — exactly the state reported, where comparing the two views detects nothing and the activity invariant is suspended by design.

This also resolves the issue's "secondary observation": the second `Requested 'BLOCKING'` was **not** silently dropped. Its task started, set the pause flag, and deadlocked. Same bug, one mechanism.

## The fix

- **`As400StreamingChangeEventSource.awaitBlockingSnapshots()`** — while paused, poll the coordinator's flag and **re-acknowledge the pause every 250 ms** instead of parking on the coordinator's condition. A snapshot task that starts while streaming is already paused gets its handshake and runs, and the acknowledgement can no longer be lost to a race. Also logs every 60 s while paused, so a long pause is never silent (the 40-minute freeze produced no output at all).
- **`WatchDog` third invariant** — `(paused, paused)` is only legitimate while a snapshot is actually running. `As400SnapshotChangeEventSource` publishes that through a shared `SnapshotActivity`, and the watchdog fails the task with the same retriable `IOException` as #27 when the pair sits idle past `blocking.snapshot.pause.timeout.ms`. Elapsed time alone cannot bound the pause — a real blocking snapshot may run for hours — which is why the extra signal is needed rather than the plain cap the issue offered as a fallback.

The pause loop itself is deliberately **not** time-bounded (issue's point 2): a timeout there would abort legitimate multi-hour snapshots. The watchdog does the bounding, with the information needed to tell the two apart.

## Tests

`As400StreamingChangeEventSourcePauseTest.queuedBlockingSnapshotsAllRunAndStreamingResumes` reproduces `ChangeEventSourceContextImpl` field for field (lock, both conditions, `paused`/`streaming`) and runs two blocking snapshots back to back on one thread, pinning the wedging interleaving under the coordinator's own lock so it is deterministic rather than a race.

Verified it is a real regression test: reverting `awaitBlockingSnapshots` to the old `waitSnapshotCompletion()` park makes it **deadlock and time out** at that exact line; with the fix it passes in ~1 s. Three new `WatchDogTest` cases cover the third wedge direction, a long-running snapshot that must not be failed, and a snapshot still starting up.

Full module suite: 91/91 green.

## Note on the base branch

Opened against `3.5`, where the #27 watchdog this builds on lives (`main` never received PR #28 and has no `blocking.snapshot.pause.timeout.ms`). `main` is missing the whole #27 fix — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)