### PR TITLE
Chunk a parallel snapshot by relative record number when the key is composite or missing (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ PARTITIONS=3
 REPLICATION_FACTOR=3
 ```
 
+## Parallel snapshot chunking
+
+With `snapshot.max.threads` above 1, Debezium splits each table into chunks and reads them in
+parallel. Out of the box the chunk key is the primary key, failing that the physical file's keyed
+access path, failing that the first unique index. Each chunk boundary is then located with an
+`ORDER BY key OFFSET n` probe that walks the index up to the boundary, and each chunk is read in key
+order, which on a large arrival-sequence file is a random page read per row. A composite key adds a
+cascading-OR predicate the optimizer tends to answer with a table scan and sort per chunk. A table
+with no key at all is read as a single chunk.
+
+`snapshot.chunk.key.mode` chooses the chunk key instead:
+
+| value | behaviour |
+|---|---|
+| `auto` (default) | single-column key: chunk on it; composite key or no key: chunk on the relative record number |
+| `key` | Debezium's stock behaviour |
+| `rrn` | always chunk on the relative record number |
+
+RRN chunking takes the number of record slots (rows plus deleted records) from
+`QSYS2.SYSPARTITIONSTAT`, splits that range evenly without any query against the table, and reads
+each chunk with `WHERE RRN(table) >= ? AND RRN(table) < ? ORDER BY RRN(table)`, a sequential scan of
+that slot range. Chunks are even in slots rather than rows, so a file carrying many deleted records
+gets uneven chunks until it is reorganised. The Kafka record key is not affected.
+
+An incremental snapshot can chunk on RRN as well: send the signal with `"surrogate-key": "RRN"`.
+
 # Limitations
 
 * TODO integrate with exit program to prevent journal loss https://github.com/jhc-systems/debezium-ibmi-exitpgm

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -156,6 +156,24 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "restarted) to avoid a silent wedge.",
             DEFAULT_BLOCKING_SNAPSHOT_PAUSE_TIMEOUT);
 
+    /**
+     * Chunk key of a parallel blocking snapshot. Debezium chunks on the table key, which on DB2 for i
+     * means an OFFSET probe walking the index once per boundary and a key-ordered read per chunk; a
+     * composite key also yields a cascading-OR predicate the optimizer tends to turn into a table scan
+     * plus sort, once per chunk. RRN ranges cost nothing to compute and read in arrival sequence.
+     */
+    public static final Field SNAPSHOT_CHUNK_KEY_MODE = Field.create("snapshot.chunk.key.mode")
+            .withDisplayName("Chunk key of a parallel (snapshot.max.threads > 1) blocking snapshot")
+            .withEnum(SnapshotChunkKeyMode.class, SnapshotChunkKeyMode.AUTO)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("How a table is split into chunks when snapshot.max.threads or its multiplier is above 1. "
+                    + "'key' chunks on the primary key, keyed access path or first unique index (Debezium's stock "
+                    + "behaviour): one index-walking OFFSET probe per boundary and a key-ordered read per chunk, and a "
+                    + "table without any key is read as a single chunk. 'rrn' chunks on the relative record number: "
+                    + "boundaries come from the catalog without touching the table and each chunk is a sequential "
+                    + "arrival-sequence read, keyless tables included. 'auto' (default) uses the key when it is a "
+                    + "single column and RRN otherwise (composite key or no key).");
+
     public static final long DEFAULT_CACHE_ADDITIONAL_DELAY = 5000;
 
     public static final Field JOURNAL_CACHE_ADDITIONAL_DELAY = Field.create("journal.additional.delay", "additional delay when journal caching is enabled",
@@ -328,6 +346,10 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public UnavailablePositionRecovery getUnavailablePositionRecovery() {
         return unavailablePositionRecovery;
+    }
+
+    public SnapshotChunkKeyMode getSnapshotChunkKeyMode() {
+        return SnapshotChunkKeyMode.parse(config.getString(SNAPSHOT_CHUNK_KEY_MODE), SNAPSHOT_CHUNK_KEY_MODE.defaultValueAsString());
     }
 
     /**
@@ -503,7 +525,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
                         DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY, TRANSACTION_MGMT_ENABLED,
                         UNAVAILABLE_POSITION_RECOVERY, SNAPSHOT_QUERY_TIME_LIMIT, MAX_RETRIEVAL_TIMEOUT, BLOCKING_SNAPSHOT_PAUSE_TIMEOUT,
-                        LOB_FETCH,
+                        SNAPSHOT_CHUNK_KEY_MODE, LOB_FETCH,
                         POINTER_HANDLE_THRESHOLD)
                 .connector(
                         SCHEMA_NAME_ADJUSTMENT_MODE)
@@ -671,6 +693,53 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
         public static UnavailablePositionRecovery parse(String value, String defaultValue) {
             UnavailablePositionRecovery mode = parse(value);
+            if (mode == null && defaultValue != null) {
+                mode = parse(defaultValue);
+            }
+            return mode;
+        }
+    }
+
+    /**
+     * Which column a parallel blocking snapshot chunks a table on. See {@link #SNAPSHOT_CHUNK_KEY_MODE}.
+     */
+    public enum SnapshotChunkKeyMode implements EnumeratedValue {
+
+        /** Single-column key: chunk on it. Composite key or no key: chunk on the relative record number. */
+        AUTO("auto"),
+
+        /** Debezium's stock behaviour: chunk on the key, single chunk when there is none. */
+        KEY("key"),
+
+        /** Always chunk on the relative record number. */
+        RRN("rrn");
+
+        private final String value;
+
+        SnapshotChunkKeyMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public static SnapshotChunkKeyMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (SnapshotChunkKeyMode option : SnapshotChunkKeyMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        public static SnapshotChunkKeyMode parse(String value, String defaultValue) {
+            SnapshotChunkKeyMode mode = parse(value);
             if (mode == null && defaultValue != null) {
                 mode = parse(defaultValue);
             }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -34,11 +34,14 @@ import io.debezium.ibmi.db2.journal.retrieve.Connect;
 import io.debezium.ibmi.db2.journal.retrieve.FileFilter;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.source.snapshot.incremental.ChunkQueryBuilder;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.ColumnNameFilter;
 import io.debezium.relational.Tables.TableFilter;
+import io.debezium.spi.schema.DataCollectionId;
 
 public class As400JdbcConnection extends JdbcConnection implements Connect<Connection, SQLException> {
     private static final Logger log = LoggerFactory.getLogger(As400JdbcConnection.class);
@@ -536,6 +539,11 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
     public String buildSelectWithRowLimits(TableId tableId, int limit, String projection,
                                            Optional<String> condition, Optional<String> additionalCondition, String orderBy,
                                            Optional<String> tableAlias) {
+        if (projection.equals(rrnExpression(tableId)) && condition.isEmpty() && additionalCondition.isEmpty()) {
+            // Max-key probe of an RRN-chunked blocking snapshot: the highest slot in use is the row count
+            // plus the deleted-record count, read from the catalog instead of walking the file backwards.
+            return rrnSlotCountQuery(tableId);
+        }
         // DB2 for i: hint an index-driven, first-n-rows plan so each incremental chunk
         // avoids materialising/sorting the whole table.
         return super.buildSelectWithRowLimits(tableId, limit, projection, condition,
@@ -544,6 +552,11 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
 
     @Override
     public String buildSelectPrimaryKeyBoundaries(TableId tableId, long size, String projection, String orderBy) {
+        if (projection.equals(rrnExpression(tableId))) {
+            // RRN-chunked table: record slots are dense, so the boundary at position n is RRN n itself.
+            // No table access at all, where the probe below walks n rows or index entries per boundary.
+            return "SELECT CAST(" + size + " AS BIGINT) FROM SYSIBM.SYSDUMMY1";
+        }
         // DB2 for i: the blocking-snapshot chunk boundary probe orders by the chunk key (often
         // unindexed) with a large OFFSET. Without a hint the Predictive Query Governor estimates a
         // full sort and can reject the query with SQL0666 on large tables (issue #21). The probe
@@ -551,6 +564,55 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         // first-row plan and keeps the estimate under QQRYTIMLMT. Mirrors the buildSelectWithRowLimits
         // hint used for incremental chunks above.
         return super.buildSelectPrimaryKeyBoundaries(tableId, size, projection, orderBy) + " OPTIMIZE FOR 1 ROW";
+    }
+
+    @Override
+    public String quoteIdentifier(String name) {
+        // The RRN chunk key is an expression, not a column, and must reach the SQL unquoted.
+        return isRrnExpression(name) ? name : super.quoteIdentifier(name);
+    }
+
+    /**
+     * The table reference the snapshot select puts in its FROM clause: schema unquoted, table quoted only
+     * when it is not a plain SQL identifier (e.g. {@code $SCHAR}).
+     */
+    public static String snapshotTableName(TableId tableId) {
+        String table = tableId.table();
+        if (!table.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+            table = "\"" + table + "\"";
+        }
+        return tableId.schema() + "." + table;
+    }
+
+    /**
+     * The relative record number of a row, usable as a chunk key. DB2 for i resolves the table designator
+     * against the exposed name of the table reference, and accepts the qualified name whether the FROM
+     * clause spelled it quoted or not.
+     */
+    public static String rrnExpression(TableId tableId) {
+        return "RRN(" + snapshotTableName(tableId) + ")";
+    }
+
+    static boolean isRrnExpression(String name) {
+        return name.startsWith("RRN(") && name.endsWith(")");
+    }
+
+    /**
+     * Highest relative record number in use, i.e. rows plus deleted slots summed over the members, from
+     * the catalog. Zero-cost where {@code COUNT(1)} or {@code MAX(RRN(t))} would read the whole file.
+     */
+    public static String rrnSlotCountQuery(TableId tableId) {
+        return "SELECT SUM(NUMBER_ROWS + NUMBER_DELETED_ROWS) FROM QSYS2.SYSPARTITIONSTAT WHERE SYSTEM_TABLE_SCHEMA = '"
+                + tableId.schema().replace("'", "''") + "' AND TABLE_NAME = '" + tableId.table().replace("'", "''") + "'";
+    }
+
+    /**
+     * Lets an incremental snapshot signal chunk on the relative record number with
+     * {@code "surrogate-key": "RRN"}, the way the Oracle connector does with ROWID.
+     */
+    @Override
+    public <T extends DataCollectionId> ChunkQueryBuilder<T> chunkQueryBuilder(RelationalDatabaseConnectorConfig connectorConfig) {
+        return new As400RrnChunkQueryBuilder<>(connectorConfig, this);
     }
 
     // Quote qualified name to handle special chars in table name

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RrnChunkQueryBuilder.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RrnChunkQueryBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import java.sql.Types;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.source.snapshot.incremental.PhysicalRowIdentifierChunkQueryBuilder;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Table;
+import io.debezium.spi.schema.DataCollectionId;
+
+/**
+ * Incremental-snapshot chunk queries keyed on the relative record number when the signal names
+ * {@code "surrogate-key": "RRN"}: {@code RRN(DBZ_RRN_ALIAS) AS "RRN", DBZ_RRN_ALIAS.* FROM t DBZ_RRN_ALIAS
+ * WHERE RRN(DBZ_RRN_ALIAS) > ? ORDER BY RRN(DBZ_RRN_ALIAS)}. Arrival-sequence paging with no index and no
+ * cascading-OR predicate, for tables whose key is composite or missing. Without that surrogate key the
+ * stock key-based chunking applies unchanged.
+ */
+public class As400RrnChunkQueryBuilder<T extends DataCollectionId> extends PhysicalRowIdentifierChunkQueryBuilder<T> {
+
+    public static final String RRN = "RRN";
+    static final String TABLE_ALIAS = "DBZ_RRN_ALIAS";
+    static final String RRN_EXPRESSION = RRN + "(" + TABLE_ALIAS + ")";
+
+    public As400RrnChunkQueryBuilder(RelationalDatabaseConnectorConfig config, JdbcConnection jdbcConnection) {
+        // RRN() is DECIMAL(15,0) on DB2 for i
+        super(config, jdbcConnection, RRN, RRN_EXPRESSION, Types.DECIMAL, Types.DECIMAL, "DECIMAL", 15, 0, true, TABLE_ALIAS);
+    }
+
+    /**
+     * Core writes the window predicate against the projected column, {@code "RRN" > ?}, which is fine
+     * for Oracle's real ROWID pseudo-column but on DB2 for i a select-list alias cannot be referenced in
+     * the WHERE clause (SQL0206). Spell the expression out instead; the ORDER BY may keep the alias.
+     */
+    @Override
+    protected void addLowerBound(IncrementalSnapshotContext<T> context, Table table, Object[] boundaryKey, StringBuilder sql) {
+        final StringBuilder bound = new StringBuilder();
+        super.addLowerBound(context, table, boundaryKey, bound);
+        final boolean rrnKey = getQueryColumns(context, table).stream().anyMatch(c -> RRN.equalsIgnoreCase(c.name()));
+        sql.append(rrnKey ? bound.toString().replace(jdbcConnection.quoteIdentifier(RRN), RRN_EXPRESSION) : bound);
+    }
+}

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -8,6 +8,7 @@ package io.debezium.connector.db2as400;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
@@ -32,6 +33,7 @@ import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.SnapshottingTask;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -345,18 +347,18 @@ public class As400SnapshotChangeEventSource
     protected Optional<String> getSnapshotSelect(
                                                  RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext, TableId tableId,
                                                  List<String> columns) {
-        String table = tableId.table();
-        // quote names that aren't plain SQL identifiers (e.g. $SCHAR)
-        if (!table.matches("[A-Za-z_][A-Za-z0-9_]*")) {
-            table = "\"" + table + "\"";
-        }
-        String fullTableName = String.format("%s.%s", tableId.schema(), table);
-        return snapshotterService.getSnapshotQuery().snapshotQuery(fullTableName, columns);
+        return snapshotterService.getSnapshotQuery().snapshotQuery(As400JdbcConnection.snapshotTableName(tableId), columns);
     }
 
     @Override
     protected Long rowCountForTableChunked(TableId tableId) throws SQLException {
         try {
+            final Table table = schema.tableFor(tableId);
+            if (table != null && chunkByRrn(table)) {
+                log.info("Table '{}' is chunked by relative record number ({} key column(s), snapshot.chunk.key.mode={})",
+                        tableId, super.getKeyColumnsForChunking(table).size(), connectorConfig.getSnapshotChunkKeyMode().getValue());
+                return jdbcConnection.queryAndMap(As400JdbcConnection.rrnSlotCountQuery(tableId), rs -> rs.next() ? rs.getLong(1) : 0L);
+            }
             return super.rowCountForTableChunked(tableId);
         }
         catch (SQLException e) {
@@ -368,6 +370,38 @@ public class As400SnapshotChangeEventSource
             };
             throw new SQLException("Failed to count rows for table " + tableId + hint, e.getSQLState(), e.getErrorCode(), e);
         }
+    }
+
+    /**
+     * Chunk on the relative record number instead of the key where the key would be slow: core probes
+     * each boundary with an {@code ORDER BY key OFFSET n} that walks the index up to n, then reads each
+     * chunk in key order, a random page read per row on an arrival-sequence file; a composite key also
+     * yields a cascading-OR predicate the optimizer tends to answer with a table scan and sort per chunk.
+     * RRN boundaries are arithmetic over the catalog slot count and each chunk is a sequential scan.
+     */
+    @Override
+    protected List<Column> getKeyColumnsForChunking(Table table) {
+        return chunkByRrn(table) ? List.of(rrnColumn(table)) : super.getKeyColumnsForChunking(table);
+    }
+
+    private boolean chunkByRrn(Table table) {
+        return switch (connectorConfig.getSnapshotChunkKeyMode()) {
+            case KEY -> false;
+            case RRN -> true;
+            case AUTO -> super.getKeyColumnsForChunking(table).size() != 1;
+        };
+    }
+
+    private static Column rrnColumn(Table table) {
+        return Column.editor()
+                .name(As400JdbcConnection.rrnExpression(table.id()))
+                .jdbcType(Types.DECIMAL)
+                .type("DECIMAL")
+                .length(15)
+                .scale(0)
+                .optional(false)
+                .position(table.columns().size() + 1)
+                .create();
     }
 
     @Override

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionQueryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400JdbcConnectionQueryTest.java
@@ -7,12 +7,21 @@ package io.debezium.connector.db2as400;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import java.math.BigDecimal;
+import java.sql.Types;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 
 /**
@@ -52,5 +61,68 @@ public class As400JdbcConnectionQueryTest {
 
         // Then - the chunk fetch is hinted to a first-n-rows plan sized to the chunk
         assertThat(sql).endsWith(" OPTIMIZE FOR 50000 ROWS");
+    }
+
+    @Test
+    void rrn_boundary_probe_needs_no_table_access() {
+        // Given - an RRN-chunked table with 1.26 billion slots split in four
+        TableId id = new TableId(null, "ALPHAFP", "EVNT");
+        String rrn = As400JdbcConnection.rrnExpression(id);
+
+        // Then - the boundary at slot n is n itself: no OFFSET walk over the table or an index
+        assertThat(rrn).isEqualTo("RRN(ALPHAFP.EVNT)");
+        assertThat(connection.buildSelectPrimaryKeyBoundaries(id, 314_796_173L, rrn, rrn))
+                .isEqualTo("SELECT CAST(314796173 AS BIGINT) FROM SYSIBM.SYSDUMMY1");
+    }
+
+    @Test
+    void rrn_max_key_is_the_catalog_slot_count() {
+        // Given - core's max-key probe (ORDER BY key DESC FETCH FIRST 1) for the RRN chunk key
+        TableId id = new TableId(null, "ALPHAFP", "EVNT");
+        String rrn = As400JdbcConnection.rrnExpression(id);
+
+        // Then - rows plus deleted slots from the catalog, instead of walking the file backwards
+        assertThat(connection.buildSelectWithRowLimits(id, 1, rrn, Optional.empty(), Optional.empty(), rrn + " DESC"))
+                .isEqualTo("SELECT SUM(NUMBER_ROWS + NUMBER_DELETED_ROWS) FROM QSYS2.SYSPARTITIONSTAT "
+                        + "WHERE SYSTEM_TABLE_SCHEMA = 'ALPHAFP' AND TABLE_NAME = 'EVNT'");
+    }
+
+    @Test
+    void rrn_expression_reaches_the_sql_unquoted() {
+        // The chunk key goes through quoteIdentifier in the boundary probe, the WHERE and the ORDER BY
+        assertThat(connection.quoteIdentifier("RRN(ALPHAFP.EVNT)")).isEqualTo("RRN(ALPHAFP.EVNT)");
+        assertThat(As400JdbcConnection.isRrnExpression("EVCH")).isFalse();
+        // and mirrors the snapshot select's quoting of a table name that is not a plain identifier
+        assertThat(As400JdbcConnection.rrnExpression(new TableId(null, "DTEST", "$SCHAR"))).isEqualTo("RRN(DTEST.\"$SCHAR\")");
+    }
+
+    @Test
+    void incremental_rrn_window_predicate_spells_out_the_expression() {
+        // Given - an incremental snapshot signalled with "surrogate-key": "RRN", past its first chunk
+        doReturn("\"RRN\"").when(connection).quoteIdentifier("RRN");
+        final As400ConnectorConfig config = new As400ConnectorConfig(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, "ALPHAFP").build());
+        final Table table = Table.editor().tableId(new TableId(null, "ALPHAFP", "EVNT"))
+                .addColumn(Column.editor().name("EVCH").jdbcType(Types.CHAR).type("CHAR").length(2).optional(false).create())
+                .create();
+        final SignalBasedIncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>(false);
+        context.addDataCollectionNamesToSnapshot("c1", List.of("ALPHAFP.EVNT"), List.of(), "RRN");
+        context.maximumKey(new Object[]{ new BigDecimal(1_259_184_693L) });
+        context.nextChunkPosition(new Object[]{ new BigDecimal(1024) });
+
+        final As400RrnChunkQueryBuilder<TableId> builder = new As400RrnChunkQueryBuilder<>(config, connection);
+        final Table prepared = builder.prepareTable(context, table);
+        String sql = builder.buildChunkQuery(context, prepared, 1024, Optional.empty());
+
+        // Then - the RRN is projected under an alias, but the window predicate uses the expression,
+        // since DB2 for i cannot resolve a select-list alias in the WHERE clause (SQL0206)
+        assertThat(prepared.retrieveColumnNames()).containsExactly("EVCH", "RRN");
+        assertThat(sql)
+                .startsWith("SELECT RRN(DBZ_RRN_ALIAS) AS \"RRN\", DBZ_RRN_ALIAS.* FROM \"ALPHAFP\".\"EVNT\" DBZ_RRN_ALIAS")
+                .contains(" WHERE (RRN(DBZ_RRN_ALIAS) > ?) AND NOT (RRN(DBZ_RRN_ALIAS) > ?) ORDER BY \"RRN\"")
+                .doesNotContain("\"RRN\" >")
+                .endsWith(" OPTIMIZE FOR 1024 ROWS");
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceRrnChunkingTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSourceRrnChunkingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import io.debezium.snapshot.SnapshotterService;
+import io.debezium.util.Clock;
+
+/**
+ * Which column a parallel blocking snapshot chunks on: the key, or the relative record number when the
+ * key is composite or missing (ALPHAFP.EVNT: 1.26 billion rows, no primary key, a 7-column unique index).
+ */
+class As400SnapshotChangeEventSourceRrnChunkingTest {
+
+    private static final TableId EVNT = new TableId(null, "ALPHAFP", "EVNT");
+    private static final String RRN = "RRN(ALPHAFP.EVNT)";
+    private static final String[] EVNTL1 = { "EVCH", "EVCE", "EVCS", "EVCOL", "EVPT", "EVDISC", "EVCHR" };
+
+    private final As400JdbcConnection connection = mock(As400JdbcConnection.class);
+    private final As400DatabaseSchema schema = mock(As400DatabaseSchema.class);
+
+    private static Table table(String... keyColumns) {
+        final TableEditor editor = Table.editor().tableId(EVNT);
+        for (String name : List.of("EVCH", "EVCE", "EVCS", "EVCOL", "EVPT", "EVDISC", "EVCHR", "EVTYEV")) {
+            editor.addColumn(Column.editor().name(name).jdbcType(Types.CHAR).type("CHAR").length(10).optional(false).create());
+        }
+        return editor.setPrimaryKeyNames(keyColumns).create();
+    }
+
+    @SuppressWarnings("unchecked")
+    private As400SnapshotChangeEventSource source(String mode) {
+        final Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, "ALPHAFP");
+        if (mode != null) {
+            builder.with(As400ConnectorConfig.SNAPSHOT_CHUNK_KEY_MODE, mode);
+        }
+        final MainConnectionProvidingConnectionFactory<As400JdbcConnection> factory = mock(MainConnectionProvidingConnectionFactory.class);
+        when(factory.mainConnection()).thenReturn(connection);
+        return new As400SnapshotChangeEventSource(new As400ConnectorConfig(builder.build()),
+                mock(As400RpcConnection.class), factory, schema,
+                mock(EventDispatcher.class), Clock.SYSTEM, mock(SnapshotProgressListener.class),
+                mock(NotificationService.class), mock(SnapshotterService.class));
+    }
+
+    private static List<String> chunkKey(As400SnapshotChangeEventSource source, Table table) {
+        return source.getKeyColumnsForChunking(table).stream().map(Column::name).toList();
+    }
+
+    @Test
+    void auto_mode_chunks_a_composite_key_by_rrn() {
+        assertThat(chunkKey(source(null), table(EVNTL1))).containsExactly(RRN);
+    }
+
+    @Test
+    void auto_mode_chunks_a_keyless_table_by_rrn() {
+        // core would otherwise read the whole table as a single chunk
+        assertThat(chunkKey(source(null), table())).containsExactly(RRN);
+    }
+
+    @Test
+    void auto_mode_keeps_a_single_column_key() {
+        assertThat(chunkKey(source(null), table("EVCH"))).containsExactly("EVCH");
+    }
+
+    @Test
+    void key_mode_is_the_stock_behaviour() {
+        assertThat(chunkKey(source("key"), table(EVNTL1))).containsExactly(EVNTL1);
+        assertThat(chunkKey(source("key"), table())).isEmpty();
+    }
+
+    @Test
+    void rrn_mode_overrides_a_single_column_key() {
+        assertThat(chunkKey(source("rrn"), table("EVCH"))).containsExactly(RRN);
+    }
+
+    @Test
+    void rrn_column_is_the_decimal_rrn_returns() {
+        final Column rrn = source(null).getKeyColumnsForChunking(table()).get(0);
+        assertThat(rrn.jdbcType()).isEqualTo(Types.DECIMAL);
+        assertThat(rrn.isOptional()).isFalse();
+    }
+
+    @Test
+    void rrn_chunked_table_takes_its_slot_count_from_the_catalog() throws Exception {
+        when(schema.tableFor(EVNT)).thenReturn(table(EVNTL1));
+        when(connection.queryAndMap(contains("QSYS2.SYSPARTITIONSTAT"), any())).thenReturn(1_259_184_693L);
+
+        assertThat(source(null).rowCountForTableChunked(EVNT)).isEqualTo(1_259_184_693L);
+    }
+
+    @Test
+    void key_chunked_table_is_still_counted_by_core() throws Exception {
+        when(schema.tableFor(EVNT)).thenReturn(table("EVCH"));
+        when(connection.queryAndMap(contains("COUNT(1)"), any())).thenReturn(42L);
+
+        assertThat(source(null).rowCountForTableChunked(EVNT)).isEqualTo(42L);
+    }
+}


### PR DESCRIPTION
Closes #76.

## Problem

With `snapshot.max.threads` above 1, core chunks each table on its key. On DB2 for i that is one `ORDER BY key OFFSET n` probe per boundary, walking the index up to n, then a key-ordered read per chunk, a random page read per row on an arrival-sequence file. A composite key adds the cascading-OR predicate the optimizer tends to turn into a table scan plus sort per chunk. `X` (1 billion rows, no primary key, 7-column unique index Y) crawled. A table with no key at all was read as a single chunk.

## Change

- **`snapshot.chunk.key.mode`** (`As400ConnectorConfig`): `auto` (default) keeps a single-column key and switches a composite or missing key to RRN; `key` is the stock behaviour; `rrn` forces RRN.
- **`As400SnapshotChangeEventSource`** overrides `getKeyColumnsForChunking` to hand core a synthetic `RRN(SCHEMA.TABLE)` column, and `rowCountForTableChunked` to take the slot count (rows plus deleted records) from `QSYS2.SYSPARTITIONSTAT` instead of `COUNT(1)`. One INFO line per RRN-chunked table.
- **`As400JdbcConnection`**: the boundary probe becomes `SELECT CAST(n AS BIGINT) FROM SYSIBM.SYSDUMMY1` (slots are dense, so the boundary at position n is RRN n), the max-key probe becomes the same catalog slot count, and `quoteIdentifier` passes the RRN expression through unquoted. `chunkQueryBuilder` returns the new builder below.
- **`As400RrnChunkQueryBuilder`** (new): `PhysicalRowIdentifierChunkQueryBuilder` for incremental snapshots signalled with `"surrogate-key": "RRN"`, mirroring Oracle's ROWID. Overrides `addLowerBound` because DB2 for i cannot reference a select-list alias in WHERE (SQL0206).
- README section "Parallel snapshot chunking".

The Kafka record key is unaffected. `message.key.columns` still feeds the width test in `auto`.

## Verification

- Unit tests: `As400SnapshotChangeEventSourceRrnChunkingTest` (mode matrix, catalog slot count) and three new cases in `As400JdbcConnectionQueryTest` (boundary SQL, max-key SQL, unquoted expression, incremental window predicate). Full connector suite green (158 + 99).
- Live on PYP31, driving core's real `ChunkBoundaryCalculator` and `SnapshotChunkQueryBuilder` through `As400JdbcConnection`: four RRN chunks over the 100 054-row `CUSTOMERS` table returned 100 054 distinct rows, planning took 530 ms with no table access. `RRN(SCHEMA.TABLE)` resolves whether the FROM clause is quoted or not; `RRN("TABLE")` alone fails with SQL5001. Incremental paging by RRN works past the first chunk after the `addLowerBound` rewrite.

## Caveats

- Chunks are even in slots, not rows: a file carrying many deleted records gets uneven chunks until reorganised, and the progress log's row count for an RRN table is the slot count.
- A multi-member file's slot count is summed over members, which only overestimates and leaves tail chunks empty.
- Rows inserted after planning land beyond the last boundary and reach Kafka through the journal, as with key-based chunking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)