### PR TITLE
Refuse a resolved journal range that would take streaming backwards (#79)

### DIFF
--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceSkipLogTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceSkipLogTest.java
@@ -164,7 +164,7 @@ public class As400StreamingChangeEventSourceSkipLogTest {
 
         final As400StreamingChangeEventSource source = new As400StreamingChangeEventSource(config,
                 oneEntryBlock(undecodableEntry(), insertOnCapturedTable()), jdbcConnection(), dispatcher,
-                mock(ErrorHandler.class), Clock.SYSTEM, schema);
+                mock(ErrorHandler.class), Clock.SYSTEM, schema, new SnapshotActivity());
 
         source.execute(new SingleIterationContext(), new As400Partition(config.getLogicalName()), offsetContext);
 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -8,6 +8,7 @@ package io.debezium.ibmi.db2.journal.retrieve;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -41,7 +42,90 @@ public class ReceiverPagination {
         return Optional.empty();
     }
 
+    /**
+     * Resolves the range and refuses it if it would move streaming backwards.
+     *
+     * <p>A start earlier than the one we were given is never correct while streaming: the entries it
+     * covers have already been dispatched, and the position is committed from the end of whatever range
+     * is returned ({@code RetrieveJournal.updateOffsetFromContinuation}), so a rewind here becomes the
+     * connector's offset with nothing in the logs to show it (issue #79). The copy is taken before
+     * resolving because {@link RangeFinder} moves the caller's position in place, which is also why the
+     * caller's object is put back before the range is refused - otherwise the next poll resolves the
+     * same bad range from the position this one left behind.</p>
+     *
+     * <p>Refusing means no call is made this poll: {@code findRange} reports nothing to do, the
+     * streaming loop waits out a poll interval and resolves the range again from an unchanged position.
+     * A condition that persists therefore stalls rather than rewinding, and says so at ERROR every
+     * time.</p>
+     */
     PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
+        final JournalProcessedPosition requested = new JournalProcessedPosition(startPosition);
+        final PositionRange range = resolveRange(as400, startPosition, endPosition);
+        final String rewind = (range == null) ? null : rewindReason(requested, range);
+        if (rewind != null) {
+            log.error("REFUSING A REWIND: {}. Resolved the range {} for position {}, which would re-read entries "
+                    + "already dispatched. Cached end position {}, journal head {}, receivers {}",
+                    rewind, range, requested, cachedEndPosition, endPosition, cachedReceivers);
+            startPosition.setPosition(requested);
+            return null;
+        }
+        return range;
+    }
+
+    /**
+     * Why the resolved range would take streaming backwards, or {@code null} when it would not.
+     *
+     * <p>Two ways it can: starting before the position we were asked to carry on from, which re-reads
+     * dispatched entries; or ending before its own start, which asks the server for an inverted range
+     * and leaves the position at an end that is behind where we already are.</p>
+     */
+    private String rewindReason(JournalProcessedPosition requested, PositionRange range) {
+        // a position with no offset at all is a genuine fresh start, and legitimately resolves to the
+        // earliest retained receiver
+        if (requested.isOffsetSet()
+                && isBefore(range.start().getReceiver(), range.start().getOffset(), requested.getReceiver(), requested.getOffset())) {
+            return "the range starts before the position it was given";
+        }
+        if (isBefore(range.end().receiver(), range.end().getOffset(), range.start().getReceiver(), range.start().getOffset())) {
+            return "the range ends before it starts";
+        }
+        return null;
+    }
+
+    /**
+     * Whether one point in the journal is before another. Sequence numbers are only comparable within a
+     * receiver, so two points on different receivers are ordered by their place in the cached list,
+     * which {@code getReceivers} returns in attach order; a receiver that is not in the list at all
+     * cannot be placed, and the two are then taken to be in order.
+     */
+    private boolean isBefore(JournalReceiver receiver, BigInteger offset, JournalReceiver otherReceiver, BigInteger otherOffset) {
+        final int index = indexOfReceiver(receiver);
+        final int otherIndex = indexOfReceiver(otherReceiver);
+        if (index >= 0 && otherIndex >= 0 && index != otherIndex) {
+            return index < otherIndex;
+        }
+        // a guard must never be the thing that fails the task, so an unplaceable or absent receiver is
+        // taken to be in order rather than compared
+        if (!Objects.equals(receiver, otherReceiver)) {
+            return false;
+        }
+        return offset.compareTo(otherOffset) < 0;
+    }
+
+    /** Where a receiver sits in the cached list, or -1 when it is not in it or there is no list yet. */
+    private int indexOfReceiver(JournalReceiver receiver) {
+        if (cachedReceivers == null || receiver == null) {
+            return -1;
+        }
+        for (int i = 0; i < cachedReceivers.size(); i++) {
+            if (receiver.equals(cachedReceivers.get(i).info().receiver())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private PositionRange resolveRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final BigInteger start = startPosition.getOffset();
         final boolean fromBeginning = !startPosition.isOffsetSet() || start.equals(BigInteger.ZERO);
 
@@ -57,6 +141,11 @@ public class ReceiverPagination {
 
         if (fromBeginning) {
             DetailedJournalReceiver first = cachedReceivers.get(0);
+            // every path below that resolves a concrete range returns fromBeginning=false, so
+            // ParameterListBuilder's own "starting from beginning" warning never fires for them: say it
+            // here instead, where it is true regardless of what the range ends up being (issue #79)
+            log.warn("no usable offset in position {}, streaming will resume from the earliest retained receiver {}",
+                    startPosition, first);
             startPosition = new JournalProcessedPosition(first.start(), first.info().receiver(), Instant.EPOCH, false);
         }
 
@@ -186,6 +275,12 @@ public class ReceiverPagination {
                 if (lastReceiver != null && nextReceiver.start().compareTo(lastReceiver.end()) < 0) {
                     // we're at the end and we've processed it move start on to next receiver
                     if (startEqualsEndAndProcessed(startPosition, lastReceiver)) {
+                        // this is the caller's position, i.e. the connector's committed offset, being moved
+                        // from inside range resolution: worth a line, it is the only place that happens
+                        log.info("receiver {} starts at {}, before the end {} of {}: sequence numbers were reset, "
+                                + "moving position {} on to the start of the new receiver",
+                                nextReceiver.info().receiver(), nextReceiver.start(), lastReceiver.end(),
+                                lastReceiver.info().receiver(), startPosition);
                         startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
                     }
                     else {

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -673,6 +674,130 @@ class ReceiverPaginationTest {
 
         assertThrows(LostJournalException.class, () -> jreceivers.findRange(as400, inDeletedReceiver));
         verify(journalInfoRetrieval, times(2)).getReceivers(any(), any());
+    }
+
+    // ---- issue #79: a resolved range must never take streaming backwards ----
+
+    /** A receiver chain long enough to tell "rewound to the oldest retained receiver" apart from a small slip. */
+    private static DetailedJournalReceiver receiver(String name, long attach, long start, long end, JournalStatus status) {
+        return new DetailedJournalReceiver(
+                new JournalReceiverInfo(new JournalReceiver(name, "jlib"), new Date(attach), status, Optional.of(1)),
+                BigInteger.valueOf(start), BigInteger.valueOf(end), Optional.empty(), 1, 1);
+    }
+
+    private final DetailedJournalReceiver oldest = receiver("jOLD", 10, 1_000, 1_999, JournalStatus.OnlineSavedDetached);
+    private final DetailedJournalReceiver middle = receiver("jMID", 20, 2_000, 2_999, JournalStatus.OnlineSavedDetached);
+    private final DetailedJournalReceiver newest = receiver("jNEW", 30, 3_000, 3_500, JournalStatus.Attached);
+
+    @Test
+    void findRangeRefusesToRestartFromTheOldestReceiverWhenTheOffsetIsZeroed() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
+
+        // streaming on the newest receiver with the offset zeroed: resolving this gives the start of the
+        // oldest retained receiver, which is the 71M entry rewind of issue #79
+        final JournalProcessedPosition zeroed = new JournalProcessedPosition(BigInteger.ZERO,
+                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
+
+        assertTrue(jreceivers.findRange(as400, zeroed).isEmpty(), "the rewinding range must be refused");
+        assertEquals(new JournalReceiver("jNEW", "jlib"), zeroed.getReceiver(),
+                "the caller's position must be left where it was, or the next poll resolves the same range again");
+        assertEquals(BigInteger.ZERO, zeroed.getOffset(), "the caller's offset must be left where it was");
+    }
+
+    @Test
+    void findRangeRefusesARangeThatEndsBeforeItStarts() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(newest));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
+
+        // caught up past the delayed head reading: it only knows about 3500, we have processed 3550
+        final JournalProcessedPosition aheadOfTheDelayedHead = new JournalProcessedPosition(BigInteger.valueOf(3_550),
+                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
+
+        assertTrue(jreceivers.findRange(as400, aheadOfTheDelayedHead).isEmpty(), "the inverted range must be refused");
+        assertEquals(BigInteger.valueOf(3_550), aheadOfTheDelayedHead.getOffset(), "the caller's position must be untouched");
+    }
+
+    @Test
+    void findRangeRefusesTheRewindARollOntoAReceiverStartingAtZeroLeadsTo() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        // freshly attached and reporting no entries yet, so it starts before the receiver it follows
+        final DetailedJournalReceiver empty = receiver("jNEW", 30, 0, 0, JournalStatus.Attached);
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, empty));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(empty));
+
+        // caught up: exactly on the end of the previous receiver, processed
+        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(2_999),
+                new JournalReceiver("jMID", "jlib"), Instant.ofEpochSecond(0), true);
+
+        // the roll itself moves the position onto the new receiver, which is forward and allowed - but the
+        // receiver reports a start of zero, so it leaves a zeroed offset behind
+        jreceivers.findRange(as400, position);
+        assertEquals(new JournalReceiver("jNEW", "jlib"), position.getReceiver());
+        assertEquals(BigInteger.ZERO, position.getOffset(), "the zeroed offset the rewind is resolved from");
+
+        // the next poll is where issue #79 bites: a zeroed offset resolves to the oldest retained
+        // receiver. Refusing it stalls the connector, loudly, instead of silently re-reading 9 hours
+        assertTrue(jreceivers.findRange(as400, position).isEmpty(), "the rewinding range must be refused");
+        assertEquals(new JournalReceiver("jNEW", "jlib"), position.getReceiver(), "position left as the refused call found it");
+        assertEquals(BigInteger.ZERO, position.getOffset(), "position left as the refused call found it");
+    }
+
+    @Test
+    void findRangeAllowsAnOrdinaryForwardRange() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
+
+        // part way through the oldest receiver, catching up towards the head
+        final JournalProcessedPosition catchingUp = new JournalProcessedPosition(BigInteger.valueOf(1_500),
+                new JournalReceiver("jOLD", "jlib"), Instant.ofEpochSecond(0), true);
+
+        final Optional<PositionRange> result = jreceivers.findRange(as400, catchingUp);
+        assertEquals(new PositionRange(false, catchingUp,
+                new JournalPosition(newest.end(), newest.info().receiver())), result.get());
+    }
+
+    @Test
+    void findRangeAllowsARollOnAJournalThatResetsSequenceNumbers() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        // SEQOPT(*RESET): every receiver restarts numbering at 1, which is the case on almost every
+        // journal of the test system. The roll must not read as a rewind, or the guard stalls the
+        // connector at every receiver change
+        final DetailedJournalReceiver s1 = receiver("s1", 10, 1, 999, JournalStatus.OnlineSavedDetached);
+        final DetailedJournalReceiver s2 = receiver("s2", 20, 1, 999, JournalStatus.OnlineSavedDetached);
+        final DetailedJournalReceiver s3 = receiver("s3", 30, 1, 500, JournalStatus.Attached);
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(new ArrayList<>(Arrays.asList(s1, s2, s3)));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(s3));
+
+        // caught up on the end of s1, so the roll moves the position onto s2, back down to sequence 1
+        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(999),
+                new JournalReceiver("s1", "jlib"), Instant.ofEpochSecond(0), true);
+
+        final Optional<PositionRange> result = jreceivers.findRange(as400, position);
+        assertEquals(new JournalReceiver("s2", "jlib"), result.get().start().getReceiver(), "moved on to the next receiver");
+        assertEquals(BigInteger.ONE, result.get().start().getOffset(), "a lower sequence number, but forward in the chain");
+    }
+
+    @Test
+    void findRangeAllowsAFreshStartFromTheEarliestReceiver() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
+
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
+
+        // no offset at all: nothing has been dispatched, so the earliest receiver is the right answer
+        final Optional<PositionRange> result = jreceivers.findRange(as400, new JournalProcessedPosition());
+
+        assertEquals(oldest.start(), result.get().start().getOffset());
+        assertEquals(oldest.info().receiver(), result.get().start().getReceiver());
     }
 
 }


### PR DESCRIPTION
Closes #79 — or rather, it makes #79 stop being silent. This is step 1 of the two-step fix proposed in the issue: **the guard first**, before the root cause is established.

## What was happening

The streaming position jumped **backwards 71 237 356 entries**, to a receiver 28 links earlier in the chain, while the connector was running normally — no restart, no `ERROR`, no `WARN`, no stall, health reporting `live`/`ready` throughout. It then spent 10-14 hours re-reading and did it again. Six occurrences in eight days; lag oscillates between 0.5 minutes and 52 hours on a permanent sawtooth.

The re-read is mostly filtered entries, so it produces no obvious duplicate-delivery signature downstream, which is why reconciliation never caught it. The only trace was the offset in a periodic diagnostics line that rotates within the hour.

## The guard

`ReceiverPagination._findRange` now resolves the range as before, then compares it against the position it was given and refuses it when either:

- **the range starts before the position it was given** — those entries have already been dispatched, and the position is committed from the *end* of whatever range is returned (`RetrieveJournal.updateOffsetFromContinuation`), so the rewind silently becomes the connector's offset;
- **the range ends before it starts** — an inverted range asks the server for something meaningless and leaves the position at an end that is behind where we already are.

Refusing means no RPC is made this poll: `findRange` reports nothing to do, the streaming loop waits out a poll interval and resolves the range again from an unchanged position. **A condition that persists stalls rather than rewinding, and says so at `ERROR` every time** — with the resolved range, the supplied position, `cachedEndPosition`, the journal head and the cached receiver list, which is exactly the diagnostic the issue asks for to settle the root cause.

The caller's position is restored before refusing. `RangeFinder` moves the caller's position in place, so without that, the next poll would resolve the same bad range from the position this one left behind.

## Ordering, and why it does not fire on normal rolls

Sequence numbers are only comparable within a receiver — on this test system almost every journal uses `SEQOPT(*RESET)` and restarts numbering at 1 per receiver. So two points on different receivers are ordered by their place in the cached receiver list, which `getReceivers` returns in attach order. A receiver that is not in the list at all cannot be placed, and the two are then taken to be in order: **a guard must never be the thing that fails the task.**

A position with no offset set at all is a genuine fresh start and legitimately resolves to the earliest retained receiver, so it is exempt.

## Two log lines along the way

- Every path that resolves a concrete range returns `fromBeginning=false`, so `ParameterListBuilder`'s own "starting from beginning" warning never fired for them. The resume-from-earliest-retained-receiver is now stated where it is true, regardless of what the range ends up being.
- The roll onto a receiver whose sequence numbers were reset moves the *caller's* position — the connector's committed offset — from inside range resolution. It is the only place that happens, so it now logs at INFO.

## Tests

Five new tests in `ReceiverPaginationTest`, all against `findRange`:

| test | asserts |
|---|---|
| `findRangeRefusesToRestartFromTheOldestReceiverWhenTheOffsetIsZeroed` | the #79 rewind itself is refused, position untouched |
| `findRangeRefusesARangeThatEndsBeforeItStarts` | caught up past the delayed head reading → refused |
| `findRangeRefusesTheRewindARollOntoAReceiverStartingAtZeroLeadsTo` | the roll is allowed, the rewind it sets up on the *next* poll is refused |
| `findRangeAllowsAnOrdinaryForwardRange` | catch-up towards the head is untouched |
| `findRangeAllowsARollOnAJournalThatResetsSequenceNumbers` | `SEQOPT(*RESET)` rolls do not read as rewinds |

`mvn -pl journal-parsing -am -DskipITs test` → **178 tests, 0 failures, 0 errors**. The connector module compiles clean.

## What this does not do

It does not fix the cause. The issue's hypothesis — the sticky `cachedReceivers` interacting with the deliberately delayed head reading while receivers roll every 15-25 minutes — is still a hypothesis. This change stops the rewind from being committed and makes the next occurrence produce the evidence to settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: an unrelated build fix, carried here to get CI green

`3.5` does not currently compile its own tests, independently of this PR. `8d5b87b` (#74/#75) gave `As400StreamingChangeEventSource` a `SnapshotActivity` parameter and updated five of its six call sites; the sixth arrived on `3.5` in `51a2b2b` (#51/#70) after that work had branched, so the two merged cleanly and left `As400StreamingChangeEventSourceSkipLogTest:165` calling a constructor that no longer exists. Nothing caught it because `Build (PR Validation)` only runs on `pull_request`, so no check validated the post-merge state of `3.5` itself.

The second commit here passes `new SnapshotActivity()`, as the five sibling streaming tests already do. It is one line and belongs on `3.5` rather than in this PR — happy to split it out if you would rather land it separately, but this branch cannot be green without it.

Full reactor after the rebase onto `8d5b87b`: **279 tests, 0 failures, 0 errors** (178 `journal-parsing` + 101 `debezium-connector-ibmi`).
