### PR TITLE
Claim the release version with its tag before deploying, not after

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,7 +33,8 @@ jobs:
           DATE=$(date +%Y.%m.%d)
           BASE_VERSION="${DEBEZIUM_VERSION}-ppsk-${DATE}"
 
-          # Find the next available version by checking existing git tags.
+          # Find the next available version by checking existing git tags, which are pushed before
+          # the deploy and so cover attempts that failed part way through as well as releases.
           # If v3.4.2-ppsk-2026.03.17 is taken, try v3.4.2-ppsk-2026.03.17-1, etc.
           VERSION="${BASE_VERSION}"
           COUNTER=0
@@ -91,6 +92,17 @@ jobs:
             -DgenerateBackupPoms=false \
             -DprocessAllModules=true
 
+      # Claiming the version before the deploy, not after. The registry refuses to overwrite an
+      # artifact, so a deploy that fails part way through still leaves that version taken - and a tag
+      # written only on success would never record it, leaving every later run that day to recompute
+      # the same version and fail on `already_exists` until the date rolls over.
+      - name: Claim the release version with its tag
+        run: |
+          git -C ibmi config user.name "github-actions[bot]"
+          git -C ibmi config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C ibmi tag "v${{ steps.version.outputs.version }}"
+          git -C ibmi push origin "v${{ steps.version.outputs.version }}"
+
       - name: Deploy release to GCP Artifact Registry
         run: |
           ./ibmi/mvnw deploy \
@@ -101,10 +113,3 @@ jobs:
             -Dhttp.keepAlive=false \
             -Dmaven.wagon.http.pool=false \
             -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-
-      - name: Create and push release tag
-        run: |
-          git -C ibmi config user.name "github-actions[bot]"
-          git -C ibmi config user.email "github-actions[bot]@users.noreply.github.com"
-          git -C ibmi tag "v${{ steps.version.outputs.version }}"
-          git -C ibmi push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Releases have been unpublishable since this morning, and will stay that way until the date rolls over. This is the cause.

## What breaks

`Compute release version` picks the next `-ppsk-<date>` not already claimed by a **git tag**:

```bash
while git -C ibmi tag -l "v${VERSION}" | grep -q .; do
  COUNTER=$((COUNTER + 1))
  VERSION="${BASE_VERSION}-${COUNTER}"
done
```

but `Create and push release tag` was the **last** step, running only once the deploy had succeeded. Artifact Registry refuses to overwrite an existing artifact, so a deploy that dies part way through still consumes that version — while leaving no tag to say so. Every later run that day then recomputes the same version and is refused it.

## Both of today's runs, in sequence

| time | trigger | outcome |
|---|---|---|
| 11:40 | #75 merge | deployed the reactor pom, its tests jar and `jt400-override-ccsid` to GAR, then **failed compiling `debezium-connector-ibmi`**. Published nothing usable. Tagged nothing. |
| 12:30 | #80 merge | compiled clean, then **`400 already_exists`** on the reactor pom the 11:40 run had already pushed. |

```
[ERROR] PUT .../debezium-connector-reactor-ibmi-3.5.0.Final-ppsk-2026.09.11.pom
[ERROR] {"error":"generic::already_exists: file already exists: ..."}
```

`3.5.0.Final-ppsk-2026.09.11` now exists in GAR as a **partial**: reactor pom, reactor tests jar, `jt400-override-ccsid` — but neither `debezium-connector-ibmi` nor `journal-parsing`, the two artifacts anyone actually consumes. It is a version that can never be completed and can never be reused.

## The change

Push the tag **before** the deploy rather than after. A failed attempt then costs a version number instead of the rest of the day — which is what the `-1`, `-2` counter was there for in the first place.

The tag stops meaning "this released successfully" and starts meaning "this version number is spoken for". That is the property the counter actually needs, and the only one that survives a partial deploy.

## Notes

- Step order and YAML re-parsed clean; no other step touched.
- Tag `v3.5.0.Final-ppsk-2026.09.11` needs pushing at `8d5b87b` **before this merges**, to retire the version the 11:40 run half-consumed. Without it this merge pushes that tag, still hits `already_exists`, and only the run after that succeeds. With it, merging this publishes `3.5.0.Final-ppsk-2026.09.11-1` cleanly on the first attempt, carrying `effbde9` (the #79 rewind guard) as well as this fix.
- The partial `2026.09.11` artifacts are still in GAR and want deleting by someone with `gcloud` access.
- Separately: **nothing validates `3.5` after a merge.** `Build (PR Validation)` is `pull_request`-only, which is why this morning's broken `3.5` surfaced as a failed release rather than a failed check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
