### PR TITLE
Clamp the resolved journal range to the delayed journal head (#79)

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -78,6 +78,11 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
             final ResolvedJournal resolved = journalInfoRetrieval.resolveJournal(connection(), config.getSchema(),
                     includes, config.skipUncapturableTables());
             journalInfo = resolved.journalInfo();
+            log.info("journal {}, reading its head {}ms behind live ({}ms {} + {}ms cache wait, counted only "
+                    + "while the journal caches), poll interval {}ms",
+                    journalInfo, journalInfoRetrieval.headDelayMs(journalInfo), config.cacheAdditionalDelay(),
+                    As400ConnectorConfig.JOURNAL_CACHE_ADDITIONAL_DELAY.name(), cacheWait,
+                    config.getPollInterval().toMillis());
 
             boolean transactionMgt = config.isTransactionMgmtEnabled();
 

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -101,6 +101,15 @@ public class JournalInfoRetrieval {
         this.pollInterval = pollInterval;
     }
 
+    /**
+     * How far behind live the journal head returned by {@link #getDelayedDetailedJournalReceiver} is held.
+     * The cache wait only counts for a journal that caches, so zeroing the additional delay does not
+     * switch the delay off.
+     */
+    public long headDelayMs(JournalInfo journalLib) {
+        return additionalJournalDelay + (journalLib.isCaching() ? journalCacheDelay : 0l);
+    }
+
     public JournalPosition getCurrentPosition(AS400 as400, JournalInfo journalLib) throws Exception {
         final JournalReceiver ji = getReceiver(as400, journalLib);
         final BigInteger offset = getOffset(as400, ji).end();
@@ -134,7 +143,7 @@ public class JournalInfoRetrieval {
     public Optional<DetailedJournalReceiver> getDelayedDetailedJournalReceiver(AS400 as400, JournalInfo journalLib)
             throws Exception {
         DetailedJournalReceiver dr = getCurrentDetailedJournalReceiver(as400, journalLib);
-        long totalDelay = additionalJournalDelay + (journalLib.isCaching() ? journalCacheDelay : 0l);
+        long totalDelay = headDelayMs(journalLib);
         if (totalDelay > 0) {
             if (!delayedCache.containsKey(journalLib)) {
                 DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(totalDelay, pollInterval);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -162,6 +162,13 @@ public class ReceiverPagination {
             // last call to current position won't include the correct end offset so we need to refresh the list
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
             cachedEndPosition = endPosition;
+            // the list is read live, the head we are allowed to read up to is deliberately held back by the
+            // journal cache delay: without this the newly attached receiver goes into the list carrying its
+            // real end, the range resolved from it runs past the delayed head, and the next poll - which
+            // clamps that same receiver back to the delayed reading in the branch above - resolves a range
+            // ending behind the position we just committed. That range is what rewound streaming by up to
+            // max.entries with nothing in the logs (issue #79)
+            updateEndPosition(cachedReceivers, endPosition);
         }
 
         Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers,

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -707,6 +707,40 @@ class ReceiverPaginationTest {
         assertEquals(BigInteger.ZERO, zeroed.getOffset(), "the caller's offset must be left where it was");
     }
 
+    /**
+     * What produced the rewind in the first place: a poll that crosses a receiver roll resolves its range
+     * from the freshly read receiver list, whose attached receiver carries the live end, while the head we
+     * are allowed to read up to is deliberately held back by the journal cache delay. Reading past it is
+     * what leaves the next poll - which does clamp that receiver to the delayed reading - resolving a range
+     * that ends behind the position just committed.
+     */
+    @Test
+    void findRangeNeverReadsPastTheDelayedJournalHead() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000_000, journalInfo);
+
+        final DetailedJournalReceiver previous = receiver("jPRV", 10, 1, 950, JournalStatus.OnlineSavedDetached);
+        // the live list: the attached receiver has reached 1200
+        final DetailedJournalReceiver attached = receiver("jATT", 20, 1, 1_200, JournalStatus.Attached);
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(previous, attached));
+
+        // the delayed head has only reached 300 of it, the entries after that may still be in the journal cache
+        final DetailedJournalReceiver delayedHead = receiver("jATT", 20, 1, 300, JournalStatus.Attached);
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any()))
+                .thenReturn(Optional.of(previous)) // still reading back the receiver we are on
+                .thenReturn(Optional.of(delayedHead)); // and then it moves on to the attached one
+
+        // caught up with the end of the previous receiver
+        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(950),
+                previous.info().receiver(), Instant.ofEpochSecond(0), true);
+
+        jreceivers.findRange(as400, position); // primes the cache, nothing to read
+        final PositionRange range = jreceivers.findRange(as400, position).get();
+
+        assertEquals(delayedHead.info().receiver(), range.end().receiver());
+        assertEquals(BigInteger.valueOf(300), range.end().getOffset(),
+                "the range must stop at the delayed head, not at the live end of the attached receiver");
+    }
+
     @Test
     void findRangeRefusesARangeThatEndsBeforeItStarts() throws Exception {
         final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);


### PR DESCRIPTION
## Why

The journal head we are allowed to read up to is deliberately held behind live (`journal.additional.delay` + the system's journal cache wait time). The receiver list is read **live**.

`ReceiverPagination.resolveRange`'s two branches disagreed about that:

- unchanged attached receiver: `updateEndPosition` writes the delayed head over the list's entry for it, so the range stops there;
- **receiver roll**: the list was refreshed from `getReceivers()` and used as-is, carrying the new receiver's live end.

So the one poll that crosses a roll resolves a range past the delayed head. The next poll takes the first branch, clamps that receiver back to the delayed reading — now *behind* the position just committed — and `paginateInSameReceiver` returns a range whose end is lower than its start. `RetrieveJournal.install` commits the end of whatever range it is handed, so the offset moves **backwards** by however many entries the delay window held, capped by `max.entries` (default 1,000,000), with nothing above DEBUG in the logs.

That is the silent rewind of #79. #80 refuses such a range after the fact; this stops it being resolved in the first place.

Reading past the delayed head was never safe on its own terms either: with journal caching on, those entries may not be flushed yet, so the overshoot risks *missed* entries as well as duplicated ones.

## What

- `ReceiverPagination.java` — clamp the refreshed receiver list to the delayed head in the roll branch, as the other branch already does.
- `ReceiverPaginationTest#findRangeNeverReadsPastTheDelayedJournalHead` — rolls with the live list at 1200 and the delayed head at 300; fails on the unpatched code with `expected: <300> but was: <1200>`.
- `JournalInfoRetrieval.headDelayMs` — the delay expression, so the logged value cannot drift from the one used.
- `As400RpcConnection` — one startup line: the resolved journal (whose `toString` reports `isCaching`), how far behind live its head is read, the two components, and the poll interval. None of that was visible anywhere, and it decides how wide the window above is — in particular **`journal.additional.delay=0` does not switch the delay off** when the journal caches.

```
INFO journal JournalInfo [journalName=MYJRN, journalLibrary=MYLIB, isCaching=true], reading its head
     30000ms behind live (0ms journal.additional.delay + 30000ms cache wait, counted only while the
     journal caches), poll interval 2000ms
```

## Left alone

Two rolls inside one delay window can still overshoot, since only the receiver the delayed head names is clamped. Closing that means stopping the `findPosition` walk at the delayed head, which four existing tests (`testStopBeforeJournalResetsPaginate*`, `testSkippingOverEndOfFirst`) assert it runs past — a behaviour change worth deciding separately. #80's guard covers the case: it stalls loudly instead of rewinding, and self-heals once the head catches up.

Also noted, not changed: `JOURNAL_CACHE_ADDITIONAL_DELAY`'s description says it applies "when journal caching is enabled", but the code adds it unconditionally; and `DelayedDetailedJournalReceiver:39` sizes its ring 21× rather than the 1.2× its comment intends (harmless under the 1000-entry cap, but `minDelayBetweenReadings` ends up far finer than designed).

## Test

`mvn test -DskipITs` — 296 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)