### PR TITLE
Add a 'latest' journal position recovery strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Two things are done to keep this from turning into a silent crash-loop:
   | --- | --- |
   | `fail` (default) | Stop with a distinct, non-transient error (marker `IBMI_OFFSET_NO_LONGER_AVAILABLE`) so an orchestrator can reset the offset / trigger a snapshot / alert, rather than retry to death. |
   | `snapshot` | Reset the offset and let the configured `snapshot.mode` take a fresh snapshot to re-establish table state, then resume streaming from the current journal position. Use with `snapshot.mode=initial`/`always`/`when_needed`. |
-  | `earliest` | Reset streaming to the earliest available journal receiver and continue. Intended for streaming-only / `no_data` connectors. Changes between the lost position and the earliest available receiver are **unrecoverable** and a loud warning is logged. |
+  | `earliest` | Reset streaming to the earliest available journal receiver and continue. Intended for streaming-only / `no_data` connectors. Changes between the lost position and the earliest available receiver are **unrecoverable** and a loud warning is logged. Its cost scales with retention x journal rate: everything already delivered is re-read. On a busy journal this is effectively a denial of service against yourself - see below. |
+  | `latest` | Reset streaming to the current journal head and continue, replaying nothing. Recommended for streaming-only / `no_data` connectors. Changes between the lost position and the head are **unrecoverable** and a loud warning is logged - exactly the same gap as `earliest`, without the replay. |
 
   Setting `snapshot.mode=when_needed` also triggers Debezium core's own re-snapshot-on-data-error path,
   which is equivalent to `journal.unavailable.position.recovery=snapshot`.
@@ -94,6 +95,13 @@ Two things are done to keep this from turning into a silent crash-loop:
 Data already lost from pruned receivers cannot be recovered via CDC; recovery is about getting the
 connector healthy again, not replaying the gap. Ad-hoc snapshots (both incremental and blocking) are
 also supported via the signalling channel.
+
+`earliest` and `latest` therefore leave the same gap: entries between the lost position and the resume
+point are gone either way. What `earliest` adds is re-reading everything the target already has. On a
+measured deployment with 2.7 days of retention and ~15 000 entries/s, `earliest` reset the connector
+3.5 billion entries behind and it needed ~8 days to return to where it already was - longer than the
+retention window, so it could never catch up. Prefer `latest` unless the journal is low-volume and you
+specifically want the retained entries replayed.
 
 > Not to be confused with a stale JDBC connection detected mid-snapshot, which is a connection-liveness
 > issue rather than offset/position recovery.

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -169,8 +169,9 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "retention). 'fail' (default) stops with a distinct, non-transient error so an orchestrator can "
                     + "reset the offset or alert; 'snapshot' resets the offset and lets the configured snapshot.mode take "
                     + "a fresh snapshot to fill the gap; 'earliest' resets streaming to the earliest available journal "
-                    + "receiver and continues, logging that changes between the lost position and the earliest receiver "
-                    + "are unrecoverable.");
+                    + "receiver and continues, replaying the whole retained journal; 'latest' resets streaming to the "
+                    + "current journal head and continues, replaying nothing. Both 'earliest' and 'latest' log that "
+                    + "changes between the lost position and the resume point are unrecoverable.");
 
     public As400ConnectorConfig(Configuration config) {
         // Debezium treats table.include.list as regex (filters + the base snapshot's re-filter via
@@ -526,8 +527,19 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
          * Reset streaming to the earliest journal receiver still available and continue. Intended for
          * streaming-only / {@code no_data} connectors; changes between the lost position and the
          * earliest available receiver are unrecoverable and a loud warning is logged.
+         * <p>
+         * The cost of this scales with retention x journal rate: everything the target already has is
+         * re-read, and none of it is data the gap lost. On a busy journal prefer {@link #LATEST}.
          */
-        EARLIEST("earliest");
+        EARLIEST("earliest"),
+
+        /**
+         * Reset streaming to the current journal head and continue, replaying nothing. Intended for
+         * streaming-only / {@code no_data} connectors; changes between the lost position and the head
+         * are unrecoverable and a loud warning is logged - exactly as they are under {@link #EARLIEST},
+         * which recovers no extra data for the replay it costs.
+         */
+        LATEST("latest");
 
         private final String value;
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.db2as400;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.bean.StandardBeanNames;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
@@ -191,8 +193,8 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
      * Debezium core throw a generic, retried-to-death engine failure. Transient validation failures are
      * left to propagate so the engine restart is a legitimate retry.
      */
-    private void applyUnavailablePositionRecovery(As400ConnectorConfig connectorConfig, As400RpcConnection rpcConnection,
-                                                  Offsets<As400Partition, As400OffsetContext> previousOffsets) {
+    static void applyUnavailablePositionRecovery(As400ConnectorConfig connectorConfig, As400RpcConnection rpcConnection,
+                                                 Offsets<As400Partition, As400OffsetContext> previousOffsets) {
         if (!connectorConfig.isLogPositionCheckEnabled()) {
             return;
         }
@@ -207,7 +209,8 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
                     throw new OffsetNoLongerAvailableException(
                             "stored journal position " + offset.getPosition() + " is no longer available on the server "
                                     + "(pruned receiver). Reset the offset and trigger a snapshot, or set "
-                                    + "'" + As400ConnectorConfig.UNAVAILABLE_POSITION_RECOVERY.name() + "' to 'snapshot' or 'earliest' to auto-recover.");
+                                    + "'" + As400ConnectorConfig.UNAVAILABLE_POSITION_RECOVERY.name()
+                                    + "' to 'snapshot', 'latest' or 'earliest' to auto-recover.");
                 case SNAPSHOT:
                     LOGGER.warn("Stored journal position {} is no longer available (pruned receiver); resetting the offset so "
                             + "snapshot.mode '{}' can take a fresh snapshot to fill the gap.", offset.getPosition(), connectorConfig.getSnapshotMode().getValue());
@@ -219,7 +222,30 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
                             + "receiver are unrecoverable.", offset.getPosition());
                     offset.setPosition(new JournalProcessedPosition());
                     break;
+                case LATEST:
+                    final JournalProcessedPosition head = currentJournalHead(rpcConnection, offset);
+                    LOGGER.warn("DATA GAP: stored journal position {} is no longer available (pruned receiver); resetting streaming to "
+                            + "the current journal head {}. Changes between the lost position and the head are unrecoverable - as they "
+                            + "are under 'earliest', which replays the whole retained journal to recover none of them.",
+                            offset.getPosition(), head);
+                    offset.setPosition(head);
+                    break;
             }
+        }
+    }
+
+    /**
+     * The position the journal is currently attached at, marked processed so streaming resumes after it
+     * rather than re-reading it. A failure here is transient (RPC/connection), so it propagates and the
+     * engine restart is a legitimate retry rather than a silent reset to an arbitrary position.
+     */
+    private static JournalProcessedPosition currentJournalHead(As400RpcConnection rpcConnection, As400OffsetContext offset) {
+        try {
+            return new JournalProcessedPosition(rpcConnection.getCurrentPosition(), Instant.now(), true);
+        }
+        catch (As400RpcConnection.RpcException e) {
+            throw new DebeziumException("transient failure while resolving the current journal head to recover lost journal position "
+                    + offset.getPosition() + " from", e);
         }
     }
 

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigRecoveryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigRecoveryTest.java
@@ -35,6 +35,8 @@ class As400ConnectorConfigRecoveryTest {
         assertThat(config("snapshot").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.SNAPSHOT);
         assertThat(config("earliest").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.EARLIEST);
         assertThat(config("EARLIEST").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.EARLIEST);
+        assertThat(config("latest").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.LATEST);
+        assertThat(config("LATEST").getUnavailablePositionRecovery()).isEqualTo(UnavailablePositionRecovery.LATEST);
     }
 
     @Test

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorTaskRecoveryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorTaskRecoveryTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.db2as400.As400RpcConnection.PositionAvailability;
+import io.debezium.connector.db2as400.As400RpcConnection.RpcException;
+import io.debezium.ibmi.db2.journal.retrieve.JournalPosition;
+import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
+import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
+import io.debezium.pipeline.spi.Offsets;
+
+/**
+ * Verifies the {@link As400ConnectorConfig.UnavailablePositionRecovery} strategies applied at startup
+ * when the stored journal position points at a pruned receiver.
+ */
+class As400ConnectorTaskRecoveryTest {
+
+    private static final JournalReceiver LOST_RECEIVER = new JournalReceiver("RECV008", "RCV_LIB");
+    private static final JournalReceiver HEAD_RECEIVER = new JournalReceiver("RECV431", "RCV_LIB");
+    private static final BigInteger HEAD_OFFSET = BigInteger.valueOf(3_525_020_805L);
+
+    private static As400ConnectorConfig config(String recovery) {
+        return new As400ConnectorConfig(Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.UNAVAILABLE_POSITION_RECOVERY, recovery)
+                .build());
+    }
+
+    private static Offsets<As400Partition, As400OffsetContext> offsets(As400ConnectorConfig config) {
+        final JournalProcessedPosition lost = new JournalProcessedPosition(
+                BigInteger.valueOf(82), LOST_RECEIVER, Instant.ofEpochSecond(123_456L), true);
+        return Offsets.of(Map.of(new As400Partition("serverX"), new As400OffsetContext(config, lost)));
+    }
+
+    private static As400RpcConnection prunedConnection() {
+        final As400RpcConnection rpcConnection = mock(As400RpcConnection.class);
+        when(rpcConnection.checkLogPosition(any())).thenReturn(PositionAvailability.PRUNED);
+        return rpcConnection;
+    }
+
+    @Test
+    void latestResumesAtTheJournalHead() throws Exception {
+        final As400ConnectorConfig config = config("latest");
+        final Offsets<As400Partition, As400OffsetContext> previousOffsets = offsets(config);
+        final As400RpcConnection rpcConnection = prunedConnection();
+        when(rpcConnection.getCurrentPosition()).thenReturn(new JournalPosition(HEAD_OFFSET, HEAD_RECEIVER));
+
+        As400ConnectorTask.applyUnavailablePositionRecovery(config, rpcConnection, previousOffsets);
+
+        final JournalProcessedPosition recovered = previousOffsets.getTheOnlyOffset().getPosition();
+        assertThat(recovered.getReceiver()).isEqualTo(HEAD_RECEIVER);
+        assertThat(recovered.getOffset()).isEqualTo(HEAD_OFFSET);
+        // the head entry is already accounted for, so streaming resumes after it rather than re-reading it
+        assertThat(recovered.processed()).isTrue();
+    }
+
+    @Test
+    void latestLetsATransientHeadLookupFailureRetry() throws Exception {
+        final As400ConnectorConfig config = config("latest");
+        final Offsets<As400Partition, As400OffsetContext> previousOffsets = offsets(config);
+        final As400RpcConnection rpcConnection = prunedConnection();
+        when(rpcConnection.getCurrentPosition()).thenThrow(new RpcException("connection reset"));
+
+        assertThatThrownBy(() -> As400ConnectorTask.applyUnavailablePositionRecovery(config, rpcConnection, previousOffsets))
+                .isInstanceOf(DebeziumException.class)
+                .hasMessageContaining("transient");
+
+        // the stored position is left alone so the engine restart is a real retry, not a silent reset
+        assertThat(previousOffsets.getTheOnlyOffset().getPosition().getReceiver()).isEqualTo(LOST_RECEIVER);
+    }
+
+    @Test
+    void latestLeavesAnAvailablePositionAlone() throws Exception {
+        final As400ConnectorConfig config = config("latest");
+        final Offsets<As400Partition, As400OffsetContext> previousOffsets = offsets(config);
+        final As400RpcConnection rpcConnection = mock(As400RpcConnection.class);
+        when(rpcConnection.checkLogPosition(any())).thenReturn(PositionAvailability.AVAILABLE);
+
+        As400ConnectorTask.applyUnavailablePositionRecovery(config, rpcConnection, previousOffsets);
+
+        verify(rpcConnection, never()).getCurrentPosition();
+        assertThat(previousOffsets.getTheOnlyOffset().getPosition().getReceiver()).isEqualTo(LOST_RECEIVER);
+    }
+
+    @Test
+    void earliestStillResetsToABlankPosition() throws Exception {
+        final As400ConnectorConfig config = config("earliest");
+        final Offsets<As400Partition, As400OffsetContext> previousOffsets = offsets(config);
+        final As400RpcConnection rpcConnection = prunedConnection();
+
+        As400ConnectorTask.applyUnavailablePositionRecovery(config, rpcConnection, previousOffsets);
+
+        final JournalProcessedPosition recovered = previousOffsets.getTheOnlyOffset().getPosition();
+        assertThat(recovered.getReceiver()).isNull();
+        assertThat(recovered.isOffsetSet()).isFalse();
+        verify(rpcConnection, never()).getCurrentPosition();
+    }
+
+    @Test
+    void failStillThrowsAndPointsAtTheAutoRecoveryOptions() {
+        final As400ConnectorConfig config = config("fail");
+        final Offsets<As400Partition, As400OffsetContext> previousOffsets = offsets(config);
+
+        assertThatThrownBy(() -> As400ConnectorTask.applyUnavailablePositionRecovery(config, prunedConnection(), previousOffsets))
+                .isInstanceOf(OffsetNoLongerAvailableException.class)
+                .hasMessageContaining("'snapshot', 'latest' or 'earliest'");
+    }
+}


### PR DESCRIPTION
Adds `journal.unavailable.position.recovery=latest`, which resumes streaming at the current journal head when the stored position points at a pruned receiver, logging the same loud `DATA GAP` warning with the lost position and the resume point. This exists because `earliest` replays the entire retention window to recover nothing the gap did not already lose — on a measured deployment (2.7 days retention, ~15 000 entries/s) it reset the connector 3.5 billion entries behind, needing ~8 days to return to where it already was, so it could never catch up.

A failure resolving the head is transient (RPC/connection), so it propagates and leaves the stored offset untouched, keeping the engine restart a real retry rather than a silent reset. `fail` and `snapshot` are unchanged and the default is still `fail`; `earliest` is kept but its cost is now spelled out in the README table and the config description.

`applyUnavailablePositionRecovery` became package-private static (it used no instance state) so the new `As400ConnectorTaskRecoveryTest` can cover all four strategies directly.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)