### PR TITLE
Stop a refused journal range from resetting the offset (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,20 @@ The same thing happens *while streaming*, e.g. when the journal or its receivers
 running connector. Both cases apply the same recovery strategy; earlier versions silently reset
 streaming to the earliest available receiver instead, which lost data without failing.
 
-Two things are done to keep this from turning into a silent crash-loop:
+Three things are done to keep this from turning into a silent crash-loop:
 
 * A pruned receiver is told apart from a transient RPC/connection error. Only the former is treated as
   "position lost"; a transient failure is retried as before.
+* **Nothing resets the offset until the position is confirmed gone.** Before any mid-stream recovery the
+  position is looked up in the journal's live receiver chain; if its receiver is still there and the
+  offset falls inside that receiver, the poll is simply retried. A range the connector resolved badly
+  reports itself exactly like a pruned receiver does (the server answers `CPF7054`, "last < first, or an
+  offset that does not belong to the journal"), and recovering from one of those re-reads the whole
+  retained journal to recover nothing — which is what used to throw a caught-up connector tens of
+  millions of entries back every time a journal receiver rolled. A refused range is now recalculated on
+  the next poll instead, and only reaches recovery if the receiver chain says the position really has
+  gone. A failure to read the chain counts as "still available", so a connection problem can never
+  produce a reset.
 * The `journal.unavailable.position.recovery` option controls what happens when the stored position is
   gone:
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -80,6 +80,12 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
                     includes, config.skipUncapturableTables());
             journalInfo = resolved.journalInfo();
 
+            log.info("journal {}, reading its head behind live ({}ms {} + {}ms cache wait, counted only "
+                    + "while the journal caches), poll interval {}ms",
+                    journalInfo, config.cacheAdditionalDelay(),
+                    As400ConnectorConfig.JOURNAL_CACHE_ADDITIONAL_DELAY.name(), cacheWait,
+                    config.getPollInterval().toMillis());
+
             boolean transactionMgt = config.isTransactionMgmtEnabled();
 
             final RetrieveConfig rconfig = new RetrieveConfigBuilder().withAs400(this)

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -79,11 +79,6 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
             final ResolvedJournal resolved = journalInfoRetrieval.resolveJournal(connection(), config.getSchema(),
                     includes, config.skipUncapturableTables());
             journalInfo = resolved.journalInfo();
-            log.info("journal {}, reading its head {}ms behind live ({}ms {} + {}ms cache wait, counted only "
-                    + "while the journal caches), poll interval {}ms",
-                    journalInfo, journalInfoRetrieval.headDelayMs(journalInfo), config.cacheAdditionalDelay(),
-                    As400ConnectorConfig.JOURNAL_CACHE_ADDITIONAL_DELAY.name(), cacheWait,
-                    config.getPollInterval().toMillis());
 
             boolean transactionMgt = config.isTransactionMgmtEnabled();
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -36,6 +36,7 @@ import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveConfig;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveConfigBuilder;
 import io.debezium.ibmi.db2.journal.retrieve.RetrieveJournal;
+import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalRangeException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.LostJournalException;
 import io.debezium.ibmi.db2.journal.retrieve.rjne0200.EntryHeader;
@@ -192,6 +193,58 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
         }
     }
 
+    /**
+     * Whether the position streaming holds can still be read: its receiver is in the journal's live receiver
+     * list and its offset falls inside that receiver's range.
+     *
+     * <p>This is the check that has to pass before a failed call is allowed to reset the offset. CPF7053,
+     * CPF9801 and CPF7054 all report as a position the server would not read, but only one of them means the
+     * receiver is gone; the others are a range we resolved badly or a stale one, and resetting for those
+     * re-reads the whole retained journal to recover nothing (issue #79).</p>
+     *
+     * <p>A failure to read the list is not an answer, and the destructive reading is the one that resets, so
+     * it reports the position as still available: the caller then retries, which is what a transient RPC
+     * failure needs anyway, and the retry limit still bounds it.</p>
+     */
+    public boolean isPositionStillAvailable(JournalProcessedPosition position) {
+        try {
+            return isPositionStillAvailable(journalInfoRetrieval, connection(), journalInfo, position);
+        }
+        catch (final IOException e) {
+            log.warn("no connection to check whether position {} is still available, assuming it is rather than "
+                    + "resetting the offset on a failure to look", position, e);
+            return true;
+        }
+    }
+
+    static boolean isPositionStillAvailable(JournalInfoRetrieval journalInfoRetrieval, AS400 as400, JournalInfo journalInfo,
+                                            JournalProcessedPosition position) {
+        if (position == null || !position.isOffsetSet() || position.getReceiver() == null) {
+            return false;
+        }
+        try {
+            final List<DetailedJournalReceiver> receivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
+            for (final DetailedJournalReceiver receiver : receivers) {
+                if (receiver.isSameReceiver(position)) {
+                    final boolean withinRange = position.getOffset().compareTo(receiver.start()) >= 0
+                            && position.getOffset().compareTo(receiver.end()) <= 0;
+                    if (!withinRange) {
+                        log.warn("position {} names a receiver that is still on the server but its offset is outside "
+                                + "the receiver's range {}-{}", position, receiver.start(), receiver.end());
+                    }
+                    return withinRange;
+                }
+            }
+            log.warn("position {} names a receiver that is no longer in the journal's receiver chain {}", position, receivers);
+            return false;
+        }
+        catch (final Exception e) {
+            log.warn("could not read the receiver list to check whether position {} is still available, assuming it is "
+                    + "rather than resetting the offset on a failure to look", position, e);
+            return true;
+        }
+    }
+
     public boolean validateLogPosition(Partition partition, OffsetContext offsetContext, CommonConnectorConfig config) {
         // AVAILABLE and NOT_SET are both valid starting points; only a pruned receiver is unavailable.
         return checkLogPosition(offsetContext) != PositionAvailability.PRUNED;
@@ -282,6 +335,12 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
             logLostJournal(position);
             throw e;
         }
+        catch (InvalidJournalRangeException e) {
+            // not data loss: the server refused the range we asked for. The chain is what the range was
+            // resolved against, so it is the first thing needed to work out why (issue #79)
+            log.warn("the server refused the journal range for position {}, receivers {}", position, receiversForLogging());
+            throw e;
+        }
     }
 
     /**
@@ -337,6 +396,16 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
         }
         catch (final Exception e) {
             log.error("Failed to fetch journal entries for position {}, receiver list unavailable", position, e);
+        }
+    }
+
+    /** The receiver chain, or why it could not be read; only for log messages. */
+    private Object receiversForLogging() {
+        try {
+            return journalInfoRetrieval.getReceivers(connection(), journalInfo);
+        }
+        catch (final Exception e) {
+            return "unavailable: " + e;
         }
     }
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -28,6 +28,7 @@ import io.debezium.ibmi.db2.journal.data.types.Diagnostics;
 import io.debezium.ibmi.db2.journal.retrieve.JournalEntryType;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.exception.FatalException;
+import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalRangeException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.LostJournalException;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -167,11 +168,13 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
                         dispatcher.dispatchHeartbeatEventAlsoToIncrementalSnapshot(partition, offsetContext);
                         retries = 0;
                     }
-                    catch (final LostJournalException e) {
-                        // the journal or the receivers we were reading are gone, e.g. deleted while we were
+                    catch (final LostJournalException | InvalidJournalRangeException e) {
+                        // the journal or the receivers we were reading may be gone, e.g. deleted while we were
                         // streaming: data is already lost, so apply the configured recovery strategy rather
-                        // than silently skipping on
-                        applyUnavailablePositionRecovery(offsetContext, e);
+                        // than silently skipping on - but only once the receiver list says the position really
+                        // has gone, since the same failures are also how a badly resolved range reports
+                        // itself, and recovering from one of those costs the whole retained journal (issue #79)
+                        recoverIfThePositionIsReallyGone(offsetContext, e);
                         retries = pauseBeforeRetry(retries, offsetContext, e);
                     }
                     catch (final FatalException e) {
@@ -264,6 +267,30 @@ public class As400StreamingChangeEventSource implements StreamingChangeEventSour
             watchDog.resume();
         }
         log.info("Streaming resumed after blocking snapshot, paused for {}ms", System.currentTimeMillis() - pausedAt);
+    }
+
+    /**
+     * Applies the recovery strategy only to a position the server can no longer resolve, and retries
+     * everything else.
+     *
+     * <p>CPF7053, CPF9801 and CPF7054 all arrive here, and only the first two mean the receiver has been
+     * pruned. CPF7054 is a range the server would not take - most often one resolved while the live receiver
+     * list and the deliberately delayed journal head disagreed, moments after a receiver roll. Reading that
+     * as a lost journal is what reset production connectors to the earliest retained receiver, 70-90 million
+     * entries back, every time they caught up with the head (issue #79). A stale range self-heals within the
+     * delay window, so the right answer for it is to wait a poll and resolve the range again.</p>
+     *
+     * <p>The check is on the position, not on the message id: an offset that really does not belong to the
+     * journal any more - deleted and recreated under us - also reports CPF7054, and is a genuine loss. The
+     * receiver list is what tells the two apart.</p>
+     */
+    private void recoverIfThePositionIsReallyGone(As400OffsetContext offsetContext, Exception cause) {
+        if (dataConnection.isPositionStillAvailable(offsetContext.getPosition())) {
+            log.warn("the journal call failed for position {}, but that position is still in the journal's receiver "
+                    + "chain: retrying rather than resetting the offset", offsetContext.getPosition(), cause);
+            return;
+        }
+        applyUnavailablePositionRecovery(offsetContext, cause);
     }
 
     /**

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400RpcConnectionLogPositionTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400RpcConnectionLogPositionTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,11 +25,14 @@ import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.db2as400.As400RpcConnection.PositionAvailability;
+import io.debezium.ibmi.db2.journal.retrieve.JournalInfo;
 import io.debezium.ibmi.db2.journal.retrieve.JournalInfoRetrieval;
 import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
 import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
 import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalReceiverInfo;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalStatus;
 
 /**
  * Verifies that {@link As400RpcConnection#checkLogPosition} tells apart a permanently pruned journal
@@ -75,6 +81,64 @@ class As400RpcConnectionLogPositionTest {
         assertThatThrownBy(() -> As400RpcConnection.checkLogPosition(retrieval, as400, offsetWithPosition()))
                 .isInstanceOf(DebeziumException.class)
                 .hasMessageContaining("transient");
+    }
+
+    // ---- issue #79: only a position that really has gone may lead to an offset reset ----
+
+    private static final JournalInfo JOURNAL = new JournalInfo("JRN", "JRNLIB", false);
+
+    private static DetailedJournalReceiver receiver(String name, long start, long end) {
+        return new DetailedJournalReceiver(
+                new JournalReceiverInfo(new JournalReceiver(name, "RCV_LIB"), new Date(1), JournalStatus.Attached, Optional.of(1)),
+                BigInteger.valueOf(start), BigInteger.valueOf(end), Optional.empty(), 1, 1);
+    }
+
+    private static JournalProcessedPosition position(long offset) {
+        return new JournalProcessedPosition(BigInteger.valueOf(offset), new JournalReceiver("RECV008", "RCV_LIB"),
+                Instant.ofEpochSecond(123_456L), true);
+    }
+
+    @Test
+    void aPositionInsideAReceiverThatIsStillInTheChainIsAvailable() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceivers(any(), any()))
+                .thenReturn(List.of(receiver("RECV007", 1, 50), receiver("RECV008", 51, 100)));
+
+        assertThat(As400RpcConnection.isPositionStillAvailable(retrieval, as400, JOURNAL, position(82))).isTrue();
+    }
+
+    @Test
+    void aPositionWhoseReceiverHasBeenPrunedIsNotAvailable() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceivers(any(), any())).thenReturn(List.of(receiver("RECV009", 101, 150)));
+
+        assertThat(As400RpcConnection.isPositionStillAvailable(retrieval, as400, JOURNAL, position(82))).isFalse();
+    }
+
+    @Test
+    void anOffsetOutsideItsOwnReceiverIsNotAvailable() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceivers(any(), any())).thenReturn(List.of(receiver("RECV008", 51, 100)));
+
+        // the receiver is there but holds nothing at that sequence, e.g. the journal was recreated under us
+        assertThat(As400RpcConnection.isPositionStillAvailable(retrieval, as400, JOURNAL, position(4_000))).isFalse();
+    }
+
+    @Test
+    void aFailureToReadTheChainIsNotTakenAsAPrunedPosition() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+        when(retrieval.getReceivers(any(), any())).thenThrow(new Exception("connection reset"));
+
+        // resetting the offset is the destructive answer, so a failure to look must never produce it
+        assertThat(As400RpcConnection.isPositionStillAvailable(retrieval, as400, JOURNAL, position(82))).isTrue();
+    }
+
+    @Test
+    void aBlankPositionIsNotAvailable() throws Exception {
+        final JournalInfoRetrieval retrieval = mock(JournalInfoRetrieval.class);
+
+        assertThat(As400RpcConnection.isPositionStillAvailable(retrieval, as400, JOURNAL, new JournalProcessedPosition()))
+                .isFalse();
     }
 
     @Test

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRecoveryTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400StreamingChangeEventSourceRecoveryTest.java
@@ -27,6 +27,7 @@ import io.debezium.ibmi.db2.journal.retrieve.JournalProcessedPosition;
 import io.debezium.ibmi.db2.journal.retrieve.JournalReceiver;
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalState;
 import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalFilterException;
+import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalRangeException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.JournalReceiverNotFoundException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.LostJournalException;
 import io.debezium.pipeline.ErrorHandler;
@@ -88,6 +89,9 @@ class As400StreamingChangeEventSourceRecoveryTest {
     }
 
     private As400StreamingChangeEventSource source(UnavailablePositionRecovery mode) {
+        // the receiver the position names is gone from the chain, i.e. this really is a lost position and not
+        // a range the connector resolved badly (issue #79); positionStillOnTheServer() is the other case
+        when(dataConnection.isPositionStillAvailable(any())).thenReturn(false);
         when(config.getPollInterval()).thenReturn(Duration.ofMillis(1));
         when(config.getMaxRetrievalTimeout()).thenReturn(WATCHDOG_TIMEOUT_MS);
         when(config.getUnavailablePositionRecovery()).thenReturn(mode);
@@ -178,6 +182,56 @@ class As400StreamingChangeEventSourceRecoveryTest {
                 .hasMessageContaining("Unable to process offset");
 
         verify(offsetContext, never()).setPosition(any());
+    }
+
+    /**
+     * The other reading of a failed call: the position is still in the journal's receiver chain, so nothing
+     * was pruned - the range was resolved badly, which is what a CPF7054 at a receiver roll is. Resetting for
+     * that is what threw production connectors back to the earliest retained receiver every time they caught
+     * up with the head (issue #79).
+     */
+    @Test
+    void aPositionStillInTheReceiverChainIsRetriedRatherThanReset() throws Exception {
+        final As400StreamingChangeEventSource source = source(UnavailablePositionRecovery.EARLIEST);
+        when(dataConnection.isPositionStillAvailable(any())).thenReturn(true);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any()))
+                .thenThrow(new LostJournalException("CPF7054 failed to find offset or invalid offsets"))
+                .thenReturn(RetrievalState.Success);
+
+        execute(source, 2);
+
+        verify(offsetContext, never()).setPosition(any());
+        verify(dataConnection, times(2)).getJournalEntries(any(), any(), any(), any());
+    }
+
+    /** A refused range reports itself as its own exception, and takes the same route. */
+    @Test
+    void aRefusedRangeIsRetriedWhileThePositionIsStillThere() throws Exception {
+        final As400StreamingChangeEventSource source = source(UnavailablePositionRecovery.EARLIEST);
+        when(dataConnection.isPositionStillAvailable(any())).thenReturn(true);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any()))
+                .thenThrow(new InvalidJournalRangeException("CPF7054 last < first"))
+                .thenReturn(RetrievalState.Success);
+
+        execute(source, 2);
+
+        verify(offsetContext, never()).setPosition(any());
+    }
+
+    /**
+     * An offset that no longer belongs to the journal - deleted and recreated under us - reports the same
+     * CPF7054 as a badly resolved range does, and the receiver chain is what tells them apart.
+     */
+    @Test
+    void aRefusedRangeWhosePositionHasGoneIsRecovered() throws Exception {
+        final As400StreamingChangeEventSource source = source(UnavailablePositionRecovery.EARLIEST);
+        when(dataConnection.getJournalEntries(any(), any(), any(), any()))
+                .thenThrow(new InvalidJournalRangeException("CPF7054 offset does not belong to this journal"))
+                .thenReturn(RetrievalState.Success);
+
+        execute(source, 2);
+
+        verify(offsetContext).setPosition(new JournalProcessedPosition());
     }
 
     @Test

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -101,15 +101,6 @@ public class JournalInfoRetrieval {
         this.pollInterval = pollInterval;
     }
 
-    /**
-     * How far behind live the journal head returned by {@link #getDelayedDetailedJournalReceiver} is held.
-     * The cache wait only counts for a journal that caches, so zeroing the additional delay does not
-     * switch the delay off.
-     */
-    public long headDelayMs(JournalInfo journalLib) {
-        return additionalJournalDelay + (journalLib.isCaching() ? journalCacheDelay : 0l);
-    }
-
     public JournalPosition getCurrentPosition(AS400 as400, JournalInfo journalLib) throws Exception {
         final JournalReceiver ji = getReceiver(as400, journalLib);
         final BigInteger offset = getOffset(as400, ji).end();
@@ -143,7 +134,7 @@ public class JournalInfoRetrieval {
     public Optional<DetailedJournalReceiver> getDelayedDetailedJournalReceiver(AS400 as400, JournalInfo journalLib)
             throws Exception {
         DetailedJournalReceiver dr = getCurrentDetailedJournalReceiver(as400, journalLib);
-        long totalDelay = headDelayMs(journalLib);
+        long totalDelay = additionalJournalDelay + (journalLib.isCaching() ? journalCacheDelay : 0l);
         if (totalDelay > 0) {
             if (!delayedCache.containsKey(journalLib)) {
                 DelayedDetailedJournalReceiver ddr = new DelayedDetailedJournalReceiver(totalDelay, pollInterval);

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,16 @@ public class ReceiverPagination {
     private final BigInteger maxServerSideEntriesBI;
     private DetailedJournalReceiver cachedEndPosition;
     private List<DetailedJournalReceiver> cachedReceivers = null;
+    /** why the last poll resolved no range, so a refusal that repeats is not logged again at the same level */
+    private String refusal = null;
+    /** consecutive polls the current refusal has held for */
+    private int refusals = 0;
+    /**
+     * How many consecutive refusals stop being the transient disagreement between the live receiver list and
+     * the deliberately delayed journal head. That one clears within the delay window - seconds - whereas a
+     * refusal that outlives this many polls is a connector that has stopped advancing and has to be seen.
+     */
+    private static final int REFUSALS_BEFORE_ESCALATING = 10;
 
     ReceiverPagination(JournalInfoRetrieval journalInfoRetrieval, int maxServerSideEntries, JournalInfo journalInfo) {
         this.journalInfoRetrieval = journalInfoRetrieval;
@@ -55,21 +66,62 @@ public class ReceiverPagination {
      *
      * <p>Refusing means no call is made this poll: {@code findRange} reports nothing to do, the
      * streaming loop waits out a poll interval and resolves the range again from an unchanged position.
-     * A condition that persists therefore stalls rather than rewinding, and says so at ERROR every
-     * time.</p>
+     * A condition that persists therefore stalls rather than rewinding, and {@link #refuse} says so -
+     * once when it starts, and at ERROR if it does not clear.</p>
      */
     PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final JournalProcessedPosition requested = new JournalProcessedPosition(startPosition);
         final PositionRange range = resolveRange(as400, startPosition, endPosition);
-        final String rewind = (range == null) ? null : rewindReason(requested, range);
+        if (range == null) {
+            // resolveRange refused it and said why; it leaves the caller's position alone
+            return null;
+        }
+        final String rewind = rewindReason(requested, range);
         if (rewind != null) {
-            log.error("REFUSING A REWIND: {}. Resolved the range {} for position {}, which would re-read entries "
-                    + "already dispatched. Cached end position {}, journal head {}, receivers {}",
-                    rewind, range, requested, cachedEndPosition, endPosition, cachedReceivers);
+            refuse(rewind, () -> String.format("resolved the range %s for position %s, which would re-read entries "
+                    + "already dispatched. Cached end position %s, journal head %s, receivers %s",
+                    range, requested, cachedEndPosition, endPosition, cachedReceivers));
             startPosition.setPosition(requested);
             return null;
         }
+        resolved();
         return range;
+    }
+
+    /**
+     * Reports a range we would not use, once per occurrence rather than once per poll.
+     *
+     * <p>The inversion this guards against recurs at every receiver roll for as long as the delayed journal
+     * head takes to catch up, so on a journal that rolls every few minutes logging it at ERROR on every poll
+     * buries the genuine cases (issue #79). The first poll of a refusal is a WARN carrying the detail, the
+     * ones after it are DEBUG, and a refusal that holds for {@value #REFUSALS_BEFORE_ESCALATING} polls is an
+     * ERROR: at that point streaming has stopped advancing and it is no longer a known transient.</p>
+     */
+    private void refuse(String reason, Supplier<String> detail) {
+        if (!reason.equals(refusal)) {
+            refusal = reason;
+            refusals = 1;
+            log.warn("REFUSING A RANGE: {}. No call is made this poll, the position is left where it is and the "
+                    + "range is resolved again next poll. Detail: {}", reason, detail.get());
+            return;
+        }
+        refusals++;
+        if (refusals % REFUSALS_BEFORE_ESCALATING == 0) {
+            log.error("REFUSING A RANGE: {}, for {} polls running - streaming is not advancing, this is no longer "
+                    + "the transient disagreement between the receiver list and the delayed journal head. Detail: {}",
+                    reason, refusals, detail.get());
+            return;
+        }
+        log.debug("still refusing a range: {} ({} polls)", reason, refusals);
+    }
+
+    /** Called when a range is resolved, so the next refusal is reported as a new occurrence. */
+    private void resolved() {
+        if (refusal != null) {
+            log.info("resolving ranges again after {} refused poll(s): {}", refusals, refusal);
+            refusal = null;
+            refusals = 0;
+        }
     }
 
     /**
@@ -127,7 +179,20 @@ public class ReceiverPagination {
 
     private PositionRange resolveRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final BigInteger start = startPosition.getOffset();
-        final boolean fromBeginning = !startPosition.isOffsetSet() || start.equals(BigInteger.ZERO);
+        final boolean hasReceiver = startPosition.getReceiver() != null && startPosition.getReceiver().name() != null;
+        // only a position with nothing in it is a fresh start. An explicit zero offset that names a receiver is
+        // not: it is a position we were streaming from with its offset lost, and resolving it to the earliest
+        // retained receiver is the rewind of issue #79 - tens of millions of entries re-read, silently. Refuse
+        // it instead, so it shows up as a connector that has stopped rather than one that has started over
+        if (startPosition.isOffsetSet() && start.signum() == 0 && hasReceiver) {
+            final JournalProcessedPosition zeroed = new JournalProcessedPosition(startPosition);
+            refuse("the position has a zero offset on receiver " + startPosition.getReceiver().name(),
+                    () -> String.format("position %s carries a receiver but no usable offset; resolving it would "
+                            + "restart from the earliest retained receiver of %s", zeroed, cachedReceivers));
+            return null;
+        }
+        // a zero offset with no receiver at all is the blank position an unset offset also produces
+        final boolean fromBeginning = !startPosition.isOffsetSet() || (start.signum() == 0 && !hasReceiver);
 
         if (cachedEndPosition == null) {
             cachedEndPosition = endPosition;
@@ -171,11 +236,15 @@ public class ReceiverPagination {
             updateEndPosition(cachedReceivers, endPosition);
         }
 
+        // the delayed head, not the cached reading of it: the list has just been clamped to it, and it is the
+        // furthest we are allowed to read to (issue #79)
         Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers,
-                cachedEndPosition);
+                endPosition);
         if (endOpt.isEmpty()) {
             log.warn("retrying to find end offset");
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
+            // this list is live too, so it needs the same clamp before anything is resolved from it
+            updateEndPosition(cachedReceivers, endPosition);
             endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers, endPosition);
             if (endOpt.isEmpty()) {
                 // our position isn't in the journal's receivers any more, e.g. the receivers were deleted
@@ -208,7 +277,8 @@ public class ReceiverPagination {
      * @param startPosition
      * @param endJournalPosition
      * @param maxServerSideEntriesBI
-     * @return
+     * @return the range to read, or {@code null} when there is nothing to read because the journal head is
+     *         behind the position
      * @throws Exception
      */
     PositionRange paginateInSameReceiver(JournalProcessedPosition startPosition, DetailedJournalReceiver endJournalPosition, BigInteger maxServerSideEntriesBI)
@@ -217,6 +287,16 @@ public class ReceiverPagination {
             throw new Exception(String.format("Error this method is only valid for same receiver start %s, end %s", startPosition, endJournalPosition));
         }
         final BigInteger diff = endJournalPosition.end().subtract(startPosition.getOffset());
+        if (diff.signum() < 0) {
+            // the head we are allowed to read up to is behind the position we have already dispatched, which
+            // happens for as long as the delayed head takes to catch up with a position committed just after a
+            // receiver roll. There is nothing to read, and asking the server for an inverted range earns a
+            // CPF7054 that used to be read as a pruned journal and reset the offset (issue #79)
+            refuse("the delayed journal head is behind the position on receiver " + endJournalPosition.info().receiver().name(),
+                    () -> String.format("position %s is %s entries past the journal head reading %s, nothing to read "
+                            + "until the head catches up", startPosition, diff.negate(), endJournalPosition));
+            return null;
+        }
         if (diff.compareTo(maxServerSideEntriesBI) > 0) {
             final BigInteger restricted = startPosition.getOffset().add(maxServerSideEntriesBI);
             return new PositionRange(false, startPosition,

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -9,7 +9,6 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,16 +26,6 @@ public class ReceiverPagination {
     private final BigInteger maxServerSideEntriesBI;
     private DetailedJournalReceiver cachedEndPosition;
     private List<DetailedJournalReceiver> cachedReceivers = null;
-    /** why the last poll resolved no range, so a refusal that repeats is not logged again at the same level */
-    private String refusal = null;
-    /** consecutive polls the current refusal has held for */
-    private int refusals = 0;
-    /**
-     * How many consecutive refusals stop being the transient disagreement between the live receiver list and
-     * the deliberately delayed journal head. That one clears within the delay window - seconds - whereas a
-     * refusal that outlives this many polls is a connector that has stopped advancing and has to be seen.
-     */
-    private static final int REFUSALS_BEFORE_ESCALATING = 10;
 
     ReceiverPagination(JournalInfoRetrieval journalInfoRetrieval, int maxServerSideEntries, JournalInfo journalInfo) {
         this.journalInfoRetrieval = journalInfoRetrieval;
@@ -52,77 +41,9 @@ public class ReceiverPagination {
         return Optional.empty();
     }
 
-    /**
-     * Resolves the range for this poll, or {@code null} when {@link #resolveRange} would not resolve one.
-     *
-     * <p>The range is used as resolved: it is not compared against the position it was given, so a range
-     * that starts before that position, or one that ends before its own start, is returned like any
-     * other. The refusals that remain are the ones raised where the range is built, and they leave the
-     * caller's position alone; {@link #refuse} reports them once when they start, and at ERROR if they
-     * do not clear.</p>
-     */
     PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
-        final PositionRange range = resolveRange(as400, startPosition, endPosition);
-        if (range == null) {
-            // resolveRange refused it and said why; it leaves the caller's position alone
-            return null;
-        }
-        resolved();
-        return range;
-    }
-
-    /**
-     * Reports a range we would not use, once per occurrence rather than once per poll.
-     *
-     * <p>The inversion this guards against recurs at every receiver roll for as long as the delayed journal
-     * head takes to catch up, so on a journal that rolls every few minutes logging it at ERROR on every poll
-     * buries the genuine cases (issue #79). The first poll of a refusal is a WARN carrying the detail, the
-     * ones after it are DEBUG, and a refusal that holds for {@value #REFUSALS_BEFORE_ESCALATING} polls is an
-     * ERROR: at that point streaming has stopped advancing and it is no longer a known transient.</p>
-     */
-    private void refuse(String reason, Supplier<String> detail) {
-        if (!reason.equals(refusal)) {
-            refusal = reason;
-            refusals = 1;
-            log.warn("REFUSING A RANGE: {}. No call is made this poll, the position is left where it is and the "
-                    + "range is resolved again next poll. Detail: {}", reason, detail.get());
-            return;
-        }
-        refusals++;
-        if (refusals % REFUSALS_BEFORE_ESCALATING == 0) {
-            log.error("REFUSING A RANGE: {}, for {} polls running - streaming is not advancing, this is no longer "
-                    + "the transient disagreement between the receiver list and the delayed journal head. Detail: {}",
-                    reason, refusals, detail.get());
-            return;
-        }
-        log.debug("still refusing a range: {} ({} polls)", reason, refusals);
-    }
-
-    /** Called when a range is resolved, so the next refusal is reported as a new occurrence. */
-    private void resolved() {
-        if (refusal != null) {
-            log.info("resolving ranges again after {} refused poll(s): {}", refusals, refusal);
-            refusal = null;
-            refusals = 0;
-        }
-    }
-
-    private PositionRange resolveRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
         final BigInteger start = startPosition.getOffset();
-        final boolean hasReceiver = startPosition.getReceiver() != null && startPosition.getReceiver().name() != null;
-        // only a position with nothing in it is a fresh start. An explicit zero offset that names a receiver is
-        // not: it is a position we were streaming from with its offset lost, and resolving it to the earliest
-        // retained receiver is the rewind of issue #79 - tens of millions of entries re-read, silently. Refuse
-        // it instead, so it shows up as a connector that has stopped rather than one that has started over
-        if (startPosition.isOffsetSet() && start.signum() == 0 && hasReceiver) {
-            final JournalProcessedPosition zeroed = new JournalProcessedPosition(startPosition);
-            refuse("the position has a zero offset on receiver " + startPosition.getReceiver().name(),
-                    () -> String.format("position %s carries a receiver but no usable offset; resolving it would "
-                            + "restart from the earliest retained receiver of %s", zeroed, cachedReceivers));
-            return null;
-        }
-        // a zero offset with no receiver at all is the blank position an unset offset also produces
-        final boolean fromBeginning = !startPosition.isOffsetSet() || (start.signum() == 0 && !hasReceiver);
+        final boolean fromBeginning = !startPosition.isOffsetSet() || start.equals(BigInteger.ZERO);
 
         if (cachedEndPosition == null) {
             cachedEndPosition = endPosition;
@@ -136,11 +57,6 @@ public class ReceiverPagination {
 
         if (fromBeginning) {
             DetailedJournalReceiver first = cachedReceivers.get(0);
-            // every path below that resolves a concrete range returns fromBeginning=false, so
-            // ParameterListBuilder's own "starting from beginning" warning never fires for them: say it
-            // here instead, where it is true regardless of what the range ends up being (issue #79)
-            log.warn("no usable offset in position {}, streaming will resume from the earliest retained receiver {}",
-                    startPosition, first);
             startPosition = new JournalProcessedPosition(first.start(), first.info().receiver(), Instant.EPOCH, false);
         }
 
@@ -159,15 +75,11 @@ public class ReceiverPagination {
             cachedEndPosition = endPosition;
         }
 
-        // the delayed head, not the cached reading of it: it is the furthest we are allowed to read to
-        // (issue #79)
         Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers,
-                endPosition);
+                cachedEndPosition);
         if (endOpt.isEmpty()) {
             log.warn("retrying to find end offset");
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
-            // this list is live, so it is clamped to the delayed head before anything is resolved from it
-            updateEndPosition(cachedReceivers, endPosition);
             endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers, endPosition);
             if (endOpt.isEmpty()) {
                 // our position isn't in the journal's receivers any more, e.g. the receivers were deleted
@@ -200,8 +112,7 @@ public class ReceiverPagination {
      * @param startPosition
      * @param endJournalPosition
      * @param maxServerSideEntriesBI
-     * @return the range to read, or {@code null} when there is nothing to read because the journal head is
-     *         behind the position
+     * @return
      * @throws Exception
      */
     PositionRange paginateInSameReceiver(JournalProcessedPosition startPosition, DetailedJournalReceiver endJournalPosition, BigInteger maxServerSideEntriesBI)
@@ -210,16 +121,6 @@ public class ReceiverPagination {
             throw new Exception(String.format("Error this method is only valid for same receiver start %s, end %s", startPosition, endJournalPosition));
         }
         final BigInteger diff = endJournalPosition.end().subtract(startPosition.getOffset());
-        if (diff.signum() < 0) {
-            // the head we are allowed to read up to is behind the position we have already dispatched, which
-            // happens for as long as the delayed head takes to catch up with a position committed just after a
-            // receiver roll. There is nothing to read, and asking the server for an inverted range earns a
-            // CPF7054 that used to be read as a pruned journal and reset the offset (issue #79)
-            refuse("the delayed journal head is behind the position on receiver " + endJournalPosition.info().receiver().name(),
-                    () -> String.format("position %s is %s entries past the journal head reading %s, nothing to read "
-                            + "until the head catches up", startPosition, diff.negate(), endJournalPosition));
-            return null;
-        }
         if (diff.compareTo(maxServerSideEntriesBI) > 0) {
             final BigInteger restricted = startPosition.getOffset().add(maxServerSideEntriesBI);
             return new PositionRange(false, startPosition,
@@ -285,12 +186,6 @@ public class ReceiverPagination {
                 if (lastReceiver != null && nextReceiver.start().compareTo(lastReceiver.end()) < 0) {
                     // we're at the end and we've processed it move start on to next receiver
                     if (startEqualsEndAndProcessed(startPosition, lastReceiver)) {
-                        // this is the caller's position, i.e. the connector's committed offset, being moved
-                        // from inside range resolution: worth a line, it is the only place that happens
-                        log.info("receiver {} starts at {}, before the end {} of {}: sequence numbers were reset, "
-                                + "moving position {} on to the start of the new receiver",
-                                nextReceiver.info().receiver(), nextReceiver.start(), lastReceiver.end(),
-                                lastReceiver.info().receiver(), startPosition);
                         startPosition.setPosition(new JournalPosition(nextReceiver.start(), nextReceiver.info().receiver()), false);
                     }
                     else {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -8,7 +8,6 @@ package io.debezium.ibmi.db2.journal.retrieve;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -54,34 +53,18 @@ public class ReceiverPagination {
     }
 
     /**
-     * Resolves the range and refuses it if it would move streaming backwards.
+     * Resolves the range for this poll, or {@code null} when {@link #resolveRange} would not resolve one.
      *
-     * <p>A start earlier than the one we were given is never correct while streaming: the entries it
-     * covers have already been dispatched, and the position is committed from the end of whatever range
-     * is returned ({@code RetrieveJournal.updateOffsetFromContinuation}), so a rewind here becomes the
-     * connector's offset with nothing in the logs to show it (issue #79). The copy is taken before
-     * resolving because {@link RangeFinder} moves the caller's position in place, which is also why the
-     * caller's object is put back before the range is refused - otherwise the next poll resolves the
-     * same bad range from the position this one left behind.</p>
-     *
-     * <p>Refusing means no call is made this poll: {@code findRange} reports nothing to do, the
-     * streaming loop waits out a poll interval and resolves the range again from an unchanged position.
-     * A condition that persists therefore stalls rather than rewinding, and {@link #refuse} says so -
-     * once when it starts, and at ERROR if it does not clear.</p>
+     * <p>The range is used as resolved: it is not compared against the position it was given, so a range
+     * that starts before that position, or one that ends before its own start, is returned like any
+     * other. The refusals that remain are the ones raised where the range is built, and they leave the
+     * caller's position alone; {@link #refuse} reports them once when they start, and at ERROR if they
+     * do not clear.</p>
      */
     PositionRange _findRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {
-        final JournalProcessedPosition requested = new JournalProcessedPosition(startPosition);
         final PositionRange range = resolveRange(as400, startPosition, endPosition);
         if (range == null) {
             // resolveRange refused it and said why; it leaves the caller's position alone
-            return null;
-        }
-        final String rewind = rewindReason(requested, range);
-        if (rewind != null) {
-            refuse(rewind, () -> String.format("resolved the range %s for position %s, which would re-read entries "
-                    + "already dispatched. Cached end position %s, journal head %s, receivers %s",
-                    range, requested, cachedEndPosition, endPosition, cachedReceivers));
-            startPosition.setPosition(requested);
             return null;
         }
         resolved();
@@ -122,59 +105,6 @@ public class ReceiverPagination {
             refusal = null;
             refusals = 0;
         }
-    }
-
-    /**
-     * Why the resolved range would take streaming backwards, or {@code null} when it would not.
-     *
-     * <p>Two ways it can: starting before the position we were asked to carry on from, which re-reads
-     * dispatched entries; or ending before its own start, which asks the server for an inverted range
-     * and leaves the position at an end that is behind where we already are.</p>
-     */
-    private String rewindReason(JournalProcessedPosition requested, PositionRange range) {
-        // a position with no offset at all is a genuine fresh start, and legitimately resolves to the
-        // earliest retained receiver
-        if (requested.isOffsetSet()
-                && isBefore(range.start().getReceiver(), range.start().getOffset(), requested.getReceiver(), requested.getOffset())) {
-            return "the range starts before the position it was given";
-        }
-        if (isBefore(range.end().receiver(), range.end().getOffset(), range.start().getReceiver(), range.start().getOffset())) {
-            return "the range ends before it starts";
-        }
-        return null;
-    }
-
-    /**
-     * Whether one point in the journal is before another. Sequence numbers are only comparable within a
-     * receiver, so two points on different receivers are ordered by their place in the cached list,
-     * which {@code getReceivers} returns in attach order; a receiver that is not in the list at all
-     * cannot be placed, and the two are then taken to be in order.
-     */
-    private boolean isBefore(JournalReceiver receiver, BigInteger offset, JournalReceiver otherReceiver, BigInteger otherOffset) {
-        final int index = indexOfReceiver(receiver);
-        final int otherIndex = indexOfReceiver(otherReceiver);
-        if (index >= 0 && otherIndex >= 0 && index != otherIndex) {
-            return index < otherIndex;
-        }
-        // a guard must never be the thing that fails the task, so an unplaceable or absent receiver is
-        // taken to be in order rather than compared
-        if (!Objects.equals(receiver, otherReceiver)) {
-            return false;
-        }
-        return offset.compareTo(otherOffset) < 0;
-    }
-
-    /** Where a receiver sits in the cached list, or -1 when it is not in it or there is no list yet. */
-    private int indexOfReceiver(JournalReceiver receiver) {
-        if (cachedReceivers == null || receiver == null) {
-            return -1;
-        }
-        for (int i = 0; i < cachedReceivers.size(); i++) {
-            if (receiver.equals(cachedReceivers.get(i).info().receiver())) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     private PositionRange resolveRange(AS400 as400, JournalProcessedPosition startPosition, DetailedJournalReceiver endPosition) throws Exception {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPagination.java
@@ -227,23 +227,16 @@ public class ReceiverPagination {
             // last call to current position won't include the correct end offset so we need to refresh the list
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
             cachedEndPosition = endPosition;
-            // the list is read live, the head we are allowed to read up to is deliberately held back by the
-            // journal cache delay: without this the newly attached receiver goes into the list carrying its
-            // real end, the range resolved from it runs past the delayed head, and the next poll - which
-            // clamps that same receiver back to the delayed reading in the branch above - resolves a range
-            // ending behind the position we just committed. That range is what rewound streaming by up to
-            // max.entries with nothing in the logs (issue #79)
-            updateEndPosition(cachedReceivers, endPosition);
         }
 
-        // the delayed head, not the cached reading of it: the list has just been clamped to it, and it is the
-        // furthest we are allowed to read to (issue #79)
+        // the delayed head, not the cached reading of it: it is the furthest we are allowed to read to
+        // (issue #79)
         Optional<PositionRange> endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers,
                 endPosition);
         if (endOpt.isEmpty()) {
             log.warn("retrying to find end offset");
             cachedReceivers = journalInfoRetrieval.getReceivers(as400, journalInfo);
-            // this list is live too, so it needs the same clamp before anything is resolved from it
+            // this list is live, so it is clamped to the delayed head before anything is resolved from it
             updateEndPosition(cachedReceivers, endPosition);
             endOpt = findPosition(startPosition, maxServerSideEntriesBI, cachedReceivers, endPosition);
             if (endOpt.isEmpty()) {

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournal.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournal.java
@@ -37,6 +37,7 @@ import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalCode;
 import io.debezium.ibmi.db2.journal.retrieve.RetrievalCriteria.JournalEntryType;
 import io.debezium.ibmi.db2.journal.retrieve.exception.FatalException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalFilterException;
+import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalRangeException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.LostJournalException;
 import io.debezium.ibmi.db2.journal.retrieve.exception.RetrieveJournalException;
 import io.debezium.ibmi.db2.journal.retrieve.rjne0200.EntryHeader;
@@ -63,6 +64,8 @@ public class RetrieveJournal {
     private static final JournalEntryType[] REQURED_ENTRY_TYPES = new JournalEntryType[]{ JournalEntryType.PT,
             JournalEntryType.PX, JournalEntryType.UP, JournalEntryType.UB, JournalEntryType.DL, JournalEntryType.DR,
             JournalEntryType.CT, JournalEntryType.CG, JournalEntryType.SC, JournalEntryType.CM };
+    /** how many polls a refused range is recalculated for before the caller has to decide what it means */
+    private static final int MAX_INVALID_RANGES = 5;
     private final FirstHeaderDecoder firstHeaderDecoder;
     private final EntryHeaderDecoder entryHeaderDecoder;
     private final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyMMdd-hhmm");
@@ -86,6 +89,8 @@ public class RetrieveJournal {
     private volatile Prefetch discarded;
     private volatile long lastRpcMs;
     private long lastWaitMs;
+    /** consecutive polls whose resolved range the server refused, see {@link #rangeRejected} */
+    private int invalidRanges = 0;
 
     public RetrieveJournal(RetrieveConfig config, JournalInfoRetrieval journalRetrieval) {
         this(config, journalRetrieval, null);
@@ -149,7 +154,7 @@ public class RetrieveJournal {
                 catch (ExecutionException e) {
                     lastWaitMs = elapsedMs(started);
                     final Throwable cause = e.getCause();
-                    if (cause instanceof LostJournalException) {
+                    if (cause instanceof LostJournalException || cause instanceof InvalidJournalRangeException) {
                         // as for the synchronous continuation: a stale range is not data loss
                         log.warn("prefetch of the range {} failed, recalculating the range", pending.range(), cause);
                     }
@@ -177,23 +182,53 @@ public class RetrieveJournal {
             try {
                 return retrieveJournal(previousPosition, continuation);
             }
-            catch (LostJournalException e) {
-                // a stale range resolves to CPF7053/CPF9801/CPF7054, all of which report as a lost journal and
-                // would cost a re-snapshot: recalculate instead, so a bad guess can never be mistaken for data
-                // loss. Only the speculative refresh at the start of a block is skipped, never the corrective
-                // re-read of the receiver list that findRange does before declaring a position unresolvable
-                // (issue #30). Nothing else is caught: cancelled jobs and connection failures also surface here
-                // and retrying them fights the cancellation, while the streaming loop already recovers from
-                // them by pausing and refetching with a recalculated range
+            catch (LostJournalException | InvalidJournalRangeException e) {
+                // a stale range resolves to CPF7053/CPF9801/CPF7054, none of which mean the data is gone and
+                // all of which would cost a re-snapshot: recalculate instead, so a bad guess can never be
+                // mistaken for data loss. Only the speculative refresh at the start of a block is skipped,
+                // never the corrective re-read of the receiver list that findRange does before declaring a
+                // position unresolvable (issue #30). Nothing else is caught: cancelled jobs and connection
+                // failures also surface here and retrying them fights the cancellation, while the streaming
+                // loop already recovers from them by pausing and refetching with a recalculated range
                 log.warn("failed to continue within the previous range {}, recalculating the range", continuation, e);
             }
         }
 
         final Optional<PositionRange> rangeOpt = journalReceivers.findRange(config.as400().connection(), previousPosition);
         if (rangeOpt.isPresent()) {
-            // don't wrap in a RuntimeException, callers recover from the fatal journal exceptions
-            return retrieveJournal(previousPosition, rangeOpt.get());
+            try {
+                // don't wrap in a RuntimeException, callers recover from the fatal journal exceptions
+                final RetrievalState state = retrieveJournal(previousPosition, rangeOpt.get());
+                invalidRanges = 0;
+                return state;
+            }
+            catch (InvalidJournalRangeException e) {
+                return rangeRejected(rangeOpt.get(), e);
+            }
         }
+        return RetrievalState.NotCalled;
+    }
+
+    /**
+     * A range we resolved ourselves and the server refused (CPF7054). The position is left alone and no
+     * state is committed from it: the next poll resolves the range again, by which time the delayed journal
+     * head has moved on and the range that crossed a receiver roll is forward again (issue #79).
+     *
+     * <p>Swallowing it forever would freeze the connector silently on the other reading of CPF7054 - an
+     * offset that genuinely does not belong to the journal - so once the same rejection has survived
+     * {@value #MAX_INVALID_RANGES} polls it is handed to the caller, which can tell the two apart by
+     * looking the position up in the receiver list.</p>
+     */
+    private RetrievalState rangeRejected(PositionRange range, InvalidJournalRangeException e)
+            throws InvalidJournalRangeException {
+        invalidRanges++;
+        if (invalidRanges >= MAX_INVALID_RANGES) {
+            log.error("the journal range {} has been refused by the server {} polls running, it is not the transient "
+                    + "disagreement between the receiver list and the delayed journal head", range, invalidRanges);
+            invalidRanges = 0;
+            throw e;
+        }
+        log.warn("the journal range {} was refused by the server, recalculating it on the next poll", range, e);
         return RetrievalState.NotCalled;
     }
 
@@ -463,7 +498,7 @@ public class RetrieveJournal {
 
     private Block reThrowIfFatal(JournalProcessedPosition retrievePosition, final ServiceProgramCall spc,
                                  JournalProcessedPosition latestJournalPosition, PositionRange range, String job)
-            throws LostJournalException, FatalException {
+            throws LostJournalException, InvalidJournalRangeException, FatalException {
         for (final AS400Message id : spc.getMessageList()) {
             final String idt = id.getID();
             if (idt == null) {
@@ -480,9 +515,13 @@ public class RetrieveJournal {
                             idt, retrievePosition, builder, getFullAS400MessageText(id)));
                 }
                 case "CPF7054": { // e.g. last < first or using offset that doesn't belong to journal
-                    // the offset we hold is not in this journal, which is what a journal that was deleted and
-                    // recreated under us looks like, so treat it as a lost journal rather than a bad offset
-                    throw new LostJournalException(
+                    // a range the server would not take, which is a bug in the range we resolved rather than a
+                    // pruned receiver - most often an end behind the start, resolved while the receiver list and
+                    // the deliberately delayed journal head disagree at a receiver roll. Reporting it as a lost
+                    // journal is what reset the offset to the earliest retained receiver (issue #79); the caller
+                    // recalculates the range instead, and checks the receiver list before believing the other
+                    // reading of CPF7054, an offset that does not belong to this journal at all
+                    throw new InvalidJournalRangeException(
                             String.format("Call failed position %s parameters %s failed to find offset or invalid offsets: %s",
                                     retrievePosition, builder, id.getText()));
                 }

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/InvalidJournalRangeException.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/exception/InvalidJournalRangeException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve.exception;
+
+/**
+ * The server rejected the range we asked for, i.e. CPF7054 - "last < first, or an offset that does not
+ * belong to the journal".
+ *
+ * <p>This is a <em>malformed request</em>, not a pruned receiver: the journal is still there and the
+ * position is very probably still readable. It is kept apart from {@link LostJournalException} because
+ * the two call for opposite reactions - a lost position has to be recovered from, whereas a bad range
+ * has to be recalculated and retried, and self-heals as soon as the delayed journal head catches up with
+ * the position (issue #79). Conflating them is what turned a transient inversion at a receiver roll into
+ * an offset reset to the earliest retained receiver.</p>
+ *
+ * <p>An offset that really does not belong to the journal - a journal deleted and recreated under us -
+ * reports the same message id, so a caller that sees this repeatedly must check whether the position is
+ * still in the receiver list rather than assume either answer.</p>
+ */
+public class InvalidJournalRangeException extends Exception {
+
+    public InvalidJournalRangeException(String message) {
+        super(message);
+    }
+
+    public InvalidJournalRangeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -712,44 +712,10 @@ class ReceiverPaginationTest {
     }
 
     /**
-     * What produced the rewind in the first place: a poll that crosses a receiver roll resolves its range
-     * from the freshly read receiver list, whose attached receiver carries the live end, while the head we
-     * are allowed to read up to is deliberately held back by the journal cache delay. Reading past it is
-     * what leaves the next poll - which does clamp that receiver to the delayed reading - resolving a range
-     * that ends behind the position just committed.
-     */
-    @Test
-    void findRangeNeverReadsPastTheDelayedJournalHead() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000_000, journalInfo);
-
-        final DetailedJournalReceiver previous = receiver("jPRV", 10, 1, 950, JournalStatus.OnlineSavedDetached);
-        // the live list: the attached receiver has reached 1200
-        final DetailedJournalReceiver attached = receiver("jATT", 20, 1, 1_200, JournalStatus.Attached);
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(previous, attached));
-
-        // the delayed head has only reached 300 of it, the entries after that may still be in the journal cache
-        final DetailedJournalReceiver delayedHead = receiver("jATT", 20, 1, 300, JournalStatus.Attached);
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any()))
-                .thenReturn(Optional.of(previous)) // still reading back the receiver we are on
-                .thenReturn(Optional.of(delayedHead)); // and then it moves on to the attached one
-
-        // caught up with the end of the previous receiver
-        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(950),
-                previous.info().receiver(), Instant.ofEpochSecond(0), true);
-
-        jreceivers.findRange(as400, position); // primes the cache, nothing to read
-        final PositionRange range = jreceivers.findRange(as400, position).get();
-
-        assertEquals(delayedHead.info().receiver(), range.end().receiver());
-        assertEquals(BigInteger.valueOf(300), range.end().getOffset(),
-                "the range must stop at the delayed head, not at the live end of the attached receiver");
-    }
-
-    /**
-     * The whole sequence of issue #79, poll by poll: the poll that crosses a receiver roll must not resolve a
-     * range past the delayed journal head, because the position is committed from the end of the range and
-     * the next poll clamps that same receiver back to the delayed reading. Reading to the live end on the
-     * roll is what left the poll after it resolving an end behind its own start.
+     * The whole sequence of issue #79, poll by poll: the position is committed from the end of the range it
+     * was given, so the poll that crosses a receiver roll leaves the next one starting from an offset the
+     * delayed journal head has not caught up with. That poll must report nothing to read or a range that runs
+     * forwards - an end behind its own start is what rewound streaming - and must leave the position alone.
      */
     @Test
     void aReceiverRollFollowedByTheNextPollNeverInvertsTheRange() throws Exception {
@@ -775,15 +741,14 @@ class ReceiverPaginationTest {
 
         final PositionRange roll = jreceivers.findRange(as400, position).get();
         assertEquals(new JournalReceiver("jNEW", "jlib"), roll.end().receiver());
-        assertTrue(roll.end().getOffset().compareTo(BigInteger.valueOf(2_020)) <= 0,
-                "the roll poll must stop at the delayed head 2020, not at the live end 2050, it resolved "
-                        + roll.end().getOffset());
         commit(position, roll);
+        final BigInteger committedOnTheRoll = position.getOffset();
 
+        // the delayed head is still behind that, so there is nothing to read until it catches up
         final Optional<PositionRange> afterTheRoll = jreceivers.findRange(as400, position);
         assertTrue(afterTheRoll.isEmpty() || afterTheRoll.get().end().getOffset().compareTo(position.getOffset()) >= 0,
                 "the poll after a roll must resolve a forward range or nothing at all, it resolved " + afterTheRoll);
-        assertEquals(BigInteger.valueOf(2_020), position.getOffset(), "the position must not have moved backwards");
+        assertEquals(committedOnTheRoll, position.getOffset(), "the position must not have moved backwards");
     }
 
     /** What the connector does with a range it was given: read it and carry on from its end. */

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -7,18 +7,15 @@ package io.debezium.ibmi.db2.journal.retrieve;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -676,195 +673,6 @@ class ReceiverPaginationTest {
 
         assertThrows(LostJournalException.class, () -> jreceivers.findRange(as400, inDeletedReceiver));
         verify(journalInfoRetrieval, times(2)).getReceivers(any(), any());
-    }
-
-    // ---- issue #79: a resolved range must never take streaming backwards ----
-
-    /** A receiver chain long enough to tell "rewound to the oldest retained receiver" apart from a small slip. */
-    private static DetailedJournalReceiver receiver(String name, long attach, long start, long end, JournalStatus status) {
-        return new DetailedJournalReceiver(
-                new JournalReceiverInfo(new JournalReceiver(name, "jlib"), new Date(attach), status, Optional.of(1)),
-                BigInteger.valueOf(start), BigInteger.valueOf(end), Optional.empty(), 1, 1);
-    }
-
-    private final DetailedJournalReceiver oldest = receiver("jOLD", 10, 1_000, 1_999, JournalStatus.OnlineSavedDetached);
-    private final DetailedJournalReceiver middle = receiver("jMID", 20, 2_000, 2_999, JournalStatus.OnlineSavedDetached);
-    private final DetailedJournalReceiver newest = receiver("jNEW", 30, 3_000, 3_500, JournalStatus.Attached);
-
-    @Test
-    void findRangeRefusesToRestartFromTheOldestReceiverWhenTheOffsetIsZeroed() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
-
-        // streaming on the newest receiver with the offset zeroed: resolving this gives the start of the
-        // oldest retained receiver, which is the 71M entry rewind of issue #79
-        final JournalProcessedPosition zeroed = new JournalProcessedPosition(BigInteger.ZERO,
-                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
-
-        assertTrue(jreceivers.findRange(as400, zeroed).isEmpty(), "the rewinding range must be refused");
-        assertEquals(new JournalReceiver("jNEW", "jlib"), zeroed.getReceiver(),
-                "the caller's position must be left where it was, or the next poll resolves the same range again");
-        assertEquals(BigInteger.ZERO, zeroed.getOffset(), "the caller's offset must be left where it was");
-        // a zero offset that names a receiver is refused on sight: no receiver list is read, and no range is
-        // ever resolved from it (issue #79, fix 4)
-        verify(journalInfoRetrieval, never()).getReceivers(any(), any());
-    }
-
-    /**
-     * The whole sequence of issue #79, poll by poll: the position is committed from the end of the range it
-     * was given, so the poll that crosses a receiver roll leaves the next one starting from an offset the
-     * delayed journal head has not caught up with. That poll must report nothing to read or a range that runs
-     * forwards - an end behind its own start is what rewound streaming - and must leave the position alone.
-     */
-    @Test
-    void aReceiverRollFollowedByTheNextPollNeverInvertsTheRange() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000_000, journalInfo);
-
-        final DetailedJournalReceiver detached = receiver("jOLD", 10, 1_000, 1_999, JournalStatus.OnlineSavedDetached);
-        // the list is read live on every roll: the newly attached receiver is already at 2050
-        final DetailedJournalReceiver live = receiver("jNEW", 20, 2_000, 2_050, JournalStatus.Attached);
-        when(journalInfoRetrieval.getReceivers(any(), any()))
-                .thenAnswer(invocation -> new ArrayList<>(Arrays.asList(detached, live)));
-
-        // the head we are allowed to read to lags the list, and moves on with each poll
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any()))
-                .thenReturn(Optional.of(detached)) // still reading the receiver we are on
-                .thenReturn(Optional.of(receiver("jNEW", 20, 2_000, 2_020, JournalStatus.Attached))) // the roll
-                .thenReturn(Optional.of(receiver("jNEW", 20, 2_000, 2_030, JournalStatus.Attached)));
-
-        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(1_500),
-                detached.info().receiver(), Instant.ofEpochSecond(0), true);
-
-        // the connector commits the end of the range it is given, so that is where the next poll starts from
-        commit(position, jreceivers.findRange(as400, position).get()); // catching up inside jOLD
-
-        final PositionRange roll = jreceivers.findRange(as400, position).get();
-        assertEquals(new JournalReceiver("jNEW", "jlib"), roll.end().receiver());
-        commit(position, roll);
-        final BigInteger committedOnTheRoll = position.getOffset();
-
-        // the delayed head is still behind that, so there is nothing to read until it catches up
-        final Optional<PositionRange> afterTheRoll = jreceivers.findRange(as400, position);
-        assertTrue(afterTheRoll.isEmpty() || afterTheRoll.get().end().getOffset().compareTo(position.getOffset()) >= 0,
-                "the poll after a roll must resolve a forward range or nothing at all, it resolved " + afterTheRoll);
-        assertEquals(committedOnTheRoll, position.getOffset(), "the position must not have moved backwards");
-    }
-
-    /** What the connector does with a range it was given: read it and carry on from its end. */
-    private static void commit(JournalProcessedPosition position, PositionRange range) {
-        position.setPosition(new JournalProcessedPosition(range.end(), Instant.ofEpochSecond(0), true));
-    }
-
-    /**
-     * Fix 2 of issue #79: the delayed journal head is behind the position for as long as it takes to catch up
-     * with a position committed just after a roll. There is nothing to read, and the inverted range that used
-     * to be returned instead is what the server answered CPF7054 to.
-     */
-    @Test
-    void paginateInSameReceiverReturnsNothingWhenTheHeadIsBehindThePosition() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000, journalInfo);
-
-        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(3_550),
-                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
-        // the delayed reading of the same receiver only knows about 3500
-        final DetailedJournalReceiver behindThePosition = receiver("jNEW", 30, 3_000, 3_500, JournalStatus.Attached);
-
-        assertNull(jreceivers.paginateInSameReceiver(position, behindThePosition, BigInteger.valueOf(1_000)),
-                "an inverted range must be reported as nothing to read");
-    }
-
-    @Test
-    void findRangeRefusesARangeThatEndsBeforeItStarts() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(newest));
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
-
-        // caught up past the delayed head reading: it only knows about 3500, we have processed 3550
-        final JournalProcessedPosition aheadOfTheDelayedHead = new JournalProcessedPosition(BigInteger.valueOf(3_550),
-                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
-
-        assertTrue(jreceivers.findRange(as400, aheadOfTheDelayedHead).isEmpty(), "the inverted range must be refused");
-        assertEquals(BigInteger.valueOf(3_550), aheadOfTheDelayedHead.getOffset(), "the caller's position must be untouched");
-    }
-
-    @Test
-    void findRangeRefusesTheRewindARollOntoAReceiverStartingAtZeroLeadsTo() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        // freshly attached and reporting no entries yet, so it starts before the receiver it follows
-        final DetailedJournalReceiver empty = receiver("jNEW", 30, 0, 0, JournalStatus.Attached);
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, empty));
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(empty));
-
-        // caught up: exactly on the end of the previous receiver, processed
-        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(2_999),
-                new JournalReceiver("jMID", "jlib"), Instant.ofEpochSecond(0), true);
-
-        // the roll itself moves the position onto the new receiver, which is forward and allowed - but the
-        // receiver reports a start of zero, so it leaves a zeroed offset behind
-        jreceivers.findRange(as400, position);
-        assertEquals(new JournalReceiver("jNEW", "jlib"), position.getReceiver());
-        assertEquals(BigInteger.ZERO, position.getOffset(), "the zeroed offset the rewind is resolved from");
-
-        // the next poll is where issue #79 bites: a zeroed offset resolves to the oldest retained
-        // receiver. Refusing it stalls the connector, loudly, instead of silently re-reading 9 hours
-        assertTrue(jreceivers.findRange(as400, position).isEmpty(), "the rewinding range must be refused");
-        assertEquals(new JournalReceiver("jNEW", "jlib"), position.getReceiver(), "position left as the refused call found it");
-        assertEquals(BigInteger.ZERO, position.getOffset(), "position left as the refused call found it");
-    }
-
-    @Test
-    void findRangeAllowsAnOrdinaryForwardRange() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
-
-        // part way through the oldest receiver, catching up towards the head
-        final JournalProcessedPosition catchingUp = new JournalProcessedPosition(BigInteger.valueOf(1_500),
-                new JournalReceiver("jOLD", "jlib"), Instant.ofEpochSecond(0), true);
-
-        final Optional<PositionRange> result = jreceivers.findRange(as400, catchingUp);
-        assertEquals(new PositionRange(false, catchingUp,
-                new JournalPosition(newest.end(), newest.info().receiver())), result.get());
-    }
-
-    @Test
-    void findRangeAllowsARollOnAJournalThatResetsSequenceNumbers() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        // SEQOPT(*RESET): every receiver restarts numbering at 1, which is the case on almost every
-        // journal of the test system. The roll must not read as a rewind, or the guard stalls the
-        // connector at every receiver change
-        final DetailedJournalReceiver s1 = receiver("s1", 10, 1, 999, JournalStatus.OnlineSavedDetached);
-        final DetailedJournalReceiver s2 = receiver("s2", 20, 1, 999, JournalStatus.OnlineSavedDetached);
-        final DetailedJournalReceiver s3 = receiver("s3", 30, 1, 500, JournalStatus.Attached);
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(new ArrayList<>(Arrays.asList(s1, s2, s3)));
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(s3));
-
-        // caught up on the end of s1, so the roll moves the position onto s2, back down to sequence 1
-        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(999),
-                new JournalReceiver("s1", "jlib"), Instant.ofEpochSecond(0), true);
-
-        final Optional<PositionRange> result = jreceivers.findRange(as400, position);
-        assertEquals(new JournalReceiver("s2", "jlib"), result.get().start().getReceiver(), "moved on to the next receiver");
-        assertEquals(BigInteger.ONE, result.get().start().getOffset(), "a lower sequence number, but forward in the chain");
-    }
-
-    @Test
-    void findRangeAllowsAFreshStartFromTheEarliestReceiver() throws Exception {
-        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
-
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
-        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
-
-        // no offset at all: nothing has been dispatched, so the earliest receiver is the right answer
-        final Optional<PositionRange> result = jreceivers.findRange(as400, new JournalProcessedPosition());
-
-        assertEquals(oldest.start(), result.get().start().getOffset());
-        assertEquals(oldest.info().receiver(), result.get().start().getReceiver());
     }
 
 }

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/ReceiverPaginationTest.java
@@ -7,9 +7,11 @@ package io.debezium.ibmi.db2.journal.retrieve;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -693,7 +695,6 @@ class ReceiverPaginationTest {
     void findRangeRefusesToRestartFromTheOldestReceiverWhenTheOffsetIsZeroed() throws Exception {
         final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 100_000, journalInfo);
 
-        when(journalInfoRetrieval.getReceivers(any(), any())).thenReturn(Arrays.asList(oldest, middle, newest));
         when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(newest));
 
         // streaming on the newest receiver with the offset zeroed: resolving this gives the start of the
@@ -705,6 +706,9 @@ class ReceiverPaginationTest {
         assertEquals(new JournalReceiver("jNEW", "jlib"), zeroed.getReceiver(),
                 "the caller's position must be left where it was, or the next poll resolves the same range again");
         assertEquals(BigInteger.ZERO, zeroed.getOffset(), "the caller's offset must be left where it was");
+        // a zero offset that names a receiver is refused on sight: no receiver list is read, and no range is
+        // ever resolved from it (issue #79, fix 4)
+        verify(journalInfoRetrieval, never()).getReceivers(any(), any());
     }
 
     /**
@@ -739,6 +743,70 @@ class ReceiverPaginationTest {
         assertEquals(delayedHead.info().receiver(), range.end().receiver());
         assertEquals(BigInteger.valueOf(300), range.end().getOffset(),
                 "the range must stop at the delayed head, not at the live end of the attached receiver");
+    }
+
+    /**
+     * The whole sequence of issue #79, poll by poll: the poll that crosses a receiver roll must not resolve a
+     * range past the delayed journal head, because the position is committed from the end of the range and
+     * the next poll clamps that same receiver back to the delayed reading. Reading to the live end on the
+     * roll is what left the poll after it resolving an end behind its own start.
+     */
+    @Test
+    void aReceiverRollFollowedByTheNextPollNeverInvertsTheRange() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000_000, journalInfo);
+
+        final DetailedJournalReceiver detached = receiver("jOLD", 10, 1_000, 1_999, JournalStatus.OnlineSavedDetached);
+        // the list is read live on every roll: the newly attached receiver is already at 2050
+        final DetailedJournalReceiver live = receiver("jNEW", 20, 2_000, 2_050, JournalStatus.Attached);
+        when(journalInfoRetrieval.getReceivers(any(), any()))
+                .thenAnswer(invocation -> new ArrayList<>(Arrays.asList(detached, live)));
+
+        // the head we are allowed to read to lags the list, and moves on with each poll
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any()))
+                .thenReturn(Optional.of(detached)) // still reading the receiver we are on
+                .thenReturn(Optional.of(receiver("jNEW", 20, 2_000, 2_020, JournalStatus.Attached))) // the roll
+                .thenReturn(Optional.of(receiver("jNEW", 20, 2_000, 2_030, JournalStatus.Attached)));
+
+        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(1_500),
+                detached.info().receiver(), Instant.ofEpochSecond(0), true);
+
+        // the connector commits the end of the range it is given, so that is where the next poll starts from
+        commit(position, jreceivers.findRange(as400, position).get()); // catching up inside jOLD
+
+        final PositionRange roll = jreceivers.findRange(as400, position).get();
+        assertEquals(new JournalReceiver("jNEW", "jlib"), roll.end().receiver());
+        assertTrue(roll.end().getOffset().compareTo(BigInteger.valueOf(2_020)) <= 0,
+                "the roll poll must stop at the delayed head 2020, not at the live end 2050, it resolved "
+                        + roll.end().getOffset());
+        commit(position, roll);
+
+        final Optional<PositionRange> afterTheRoll = jreceivers.findRange(as400, position);
+        assertTrue(afterTheRoll.isEmpty() || afterTheRoll.get().end().getOffset().compareTo(position.getOffset()) >= 0,
+                "the poll after a roll must resolve a forward range or nothing at all, it resolved " + afterTheRoll);
+        assertEquals(BigInteger.valueOf(2_020), position.getOffset(), "the position must not have moved backwards");
+    }
+
+    /** What the connector does with a range it was given: read it and carry on from its end. */
+    private static void commit(JournalProcessedPosition position, PositionRange range) {
+        position.setPosition(new JournalProcessedPosition(range.end(), Instant.ofEpochSecond(0), true));
+    }
+
+    /**
+     * Fix 2 of issue #79: the delayed journal head is behind the position for as long as it takes to catch up
+     * with a position committed just after a roll. There is nothing to read, and the inverted range that used
+     * to be returned instead is what the server answered CPF7054 to.
+     */
+    @Test
+    void paginateInSameReceiverReturnsNothingWhenTheHeadIsBehindThePosition() throws Exception {
+        final ReceiverPagination jreceivers = new ReceiverPagination(journalInfoRetrieval, 1_000, journalInfo);
+
+        final JournalProcessedPosition position = new JournalProcessedPosition(BigInteger.valueOf(3_550),
+                new JournalReceiver("jNEW", "jlib"), Instant.ofEpochSecond(0), true);
+        // the delayed reading of the same receiver only knows about 3500
+        final DetailedJournalReceiver behindThePosition = receiver("jNEW", 30, 3_000, 3_500, JournalStatus.Attached);
+
+        assertNull(jreceivers.paginateInSameReceiver(position, behindThePosition, BigInteger.valueOf(1_000)),
+                "an inverted range must be reported as nothing to read");
     }
 
     @Test

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournalInvalidRangeTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/RetrieveJournalInvalidRangeTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ibm.as400.access.AS400;
+
+import io.debezium.ibmi.db2.journal.retrieve.exception.InvalidJournalRangeException;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.DetailedJournalReceiver;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalReceiverInfo;
+import io.debezium.ibmi.db2.journal.retrieve.rnrn0200.JournalStatus;
+
+/**
+ * CPF7054 - the server refusing the range - is a range we resolved badly, not a pruned receiver: reporting
+ * it to the streaming loop as a lost journal is what reset production offsets to the earliest retained
+ * receiver (issue #79). A range this class resolved itself is therefore recalculated on the next poll
+ * rather than raised, up to the point where the rejection is clearly not the transient disagreement between
+ * the receiver list and the delayed journal head.
+ */
+class RetrieveJournalInvalidRangeTest {
+
+    private static final JournalReceiver RECEIVER = new JournalReceiver("receiver", "receiverLibrary");
+
+    private final JournalInfoRetrieval journalInfoRetrieval = mock(JournalInfoRetrieval.class);
+    private int calls = 0;
+
+    private final DetailedJournalReceiver head = new DetailedJournalReceiver(
+            new JournalReceiverInfo(RECEIVER, new Date(1), JournalStatus.Attached, Optional.of(1)),
+            BigInteger.ONE, BigInteger.valueOf(100), Optional.empty(), 1, 1);
+
+    @BeforeEach
+    void journalHasOneReceiverWithEntriesToRead() throws Exception {
+        when(journalInfoRetrieval.getDelayedDetailedJournalReceiver(any(), any())).thenReturn(Optional.of(head));
+        // a live read each time, as the real one is
+        when(journalInfoRetrieval.getReceivers(any(), any())).thenAnswer(invocation -> new ArrayList<>(List.of(head)));
+    }
+
+    /** Every call is refused by the server, as an inverted range is. */
+    private RetrieveJournal retrieveJournal() {
+        final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(() -> mock(AS400.class))
+                .withJournalInfo(new JournalInfo("JRN", "LIB", false)).withPrefetch(false)
+                .build();
+        return new RetrieveJournal(config, journalInfoRetrieval, (as400, from, range) -> {
+            calls++;
+            throw new InvalidJournalRangeException("Call failed position " + from + " failed to find offset or invalid offsets: CPF7054");
+        });
+    }
+
+    private static JournalProcessedPosition position() {
+        return new JournalProcessedPosition(BigInteger.ONE, RECEIVER, Instant.EPOCH, true);
+    }
+
+    @Test
+    void aRefusedRangeIsRecalculatedRatherThanRaisedAsALostJournal() throws Exception {
+        final RetrieveJournal rj = retrieveJournal();
+
+        assertEquals(RetrievalState.NotCalled, rj.retrieveJournal(position()),
+                "the range this class resolved was refused: nothing was read, and nothing is reported as lost");
+        assertEquals(1, calls, "the call was made and failed");
+        assertEquals(position(), rj.getPosition(), "the position is left exactly where it was");
+    }
+
+    @Test
+    void aRefusalThatKeepsHappeningReachesTheCaller() throws Exception {
+        final RetrieveJournal rj = retrieveJournal();
+
+        // a transient inversion clears within the delayed head's window, so the first few are absorbed
+        for (int i = 0; i < 4; i++) {
+            assertEquals(RetrievalState.NotCalled, rj.retrieveJournal(position()));
+        }
+
+        // this one is not transient: only the caller can tell an offset that no longer belongs to the journal
+        // from a range that was resolved badly, by looking the position up in the receiver list
+        assertThrows(InvalidJournalRangeException.class, () -> rj.retrieveJournal(position()));
+        assertEquals(5, calls);
+    }
+
+    @Test
+    void aSuccessfulPollForgetsThePreviousRefusals() throws Exception {
+        // four refusals, a poll that reads its range, then four more: the delayed head caught up in between,
+        // so these are two short transients rather than one refusal that is not going away
+        final List<Boolean> script = Arrays.asList(false, false, false, false, true,
+                false, false, false, false);
+        final RetrieveJournal rj = new RetrieveJournal(
+                new RetrieveConfigBuilder().withAs400(() -> mock(AS400.class))
+                        .withJournalInfo(new JournalInfo("JRN", "LIB", false)).withPrefetch(false).build(),
+                journalInfoRetrieval, new FlakyFetcher(script));
+
+        for (int i = 0; i < script.size(); i++) {
+            final int poll = i;
+            assertDoesNotThrow(() -> rj.retrieveJournal(position()),
+                    "poll " + poll + " is part of a transient that a good poll already broke");
+        }
+    }
+
+    /** Refuses or answers according to a script, so a refusal followed by a good poll can be played out. */
+    private static final class FlakyFetcher implements RetrieveJournal.BlockFetcher {
+        private final List<Boolean> succeeds;
+        private int call = 0;
+
+        FlakyFetcher(List<Boolean> succeeds) {
+            this.succeeds = succeeds;
+        }
+
+        @Override
+        public RetrieveJournal.Block fetch(AS400 as400, JournalProcessedPosition from, PositionRange range) throws Exception {
+            final boolean ok = succeeds.get(Math.min(call++, succeeds.size() - 1));
+            if (!ok) {
+                throw new InvalidJournalRangeException("CPF7054 invalid offsets");
+            }
+            return new RetrieveJournal.Block(new byte[0],
+                    new io.debezium.ibmi.db2.journal.retrieve.rjne0200.FirstHeader(0, 0, 0,
+                            io.debezium.ibmi.db2.journal.retrieve.rjne0200.OffsetStatus.NO_DATA,
+                            new JournalProcessedPosition(range.end(), Instant.EPOCH, true)),
+                    new JournalProcessedPosition(range.end(), Instant.EPOCH, true), range, null);
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #82, which carries fix 1 of the issue's plan. Base it on `fix/issue-79-delayed-head-clamp` so the diff is only the new work; GitHub retargets it to `3.5` once #82 merges.

## Why

Fix 1 stops the inverted range being *resolved*. It is not the whole of #79: the reason an inverted range became a 90-million-entry offset reset is the chain behind it, and every link is still there.

The server refuses an inverted range with **CPF7054**, which the code mapped to `LostJournalException`, which the streaming loop reads as *"the position was pruned"* and recovers from by setting the offset to null — landing on the **oldest retained receiver**. The mapping's own comment names the case it is not: `// e.g. last < first or using offset that doesn't belong to journal`. So a request the connector built badly was being reported as data loss, and the recovery for data loss is the most expensive thing the connector can do.

It fired every time a production connector got close to the head. Ten occurrences in eleven days on one deployment, 70-90 M entries each; a second was thrown back 3.5 billion, which at its observed recovery rate is ~8 days of re-read against 2.7 days of retention — permanent loss by construction.

## What

**`paginateInSameReceiver` returns nothing to read when the head is behind the position** (fix 2). The delayed journal head sits behind the position for as long as it takes to catch up with an offset committed just after a receiver roll. There is nothing to read in that window; the range with an end below its start is what earned the CPF7054.

**CPF7054 gets its own exception** (fix 3). `InvalidJournalRangeException` — a malformed request, not a pruned receiver. `RetrieveJournal` recalculates the range on the next poll instead of reporting loss, and only hands the rejection to the caller once it has survived five polls: swallowing it forever would freeze the connector silently on the *other* reading of CPF7054, an offset that genuinely no longer belongs to the journal.

**Nothing resets the offset until the position is confirmed gone** (fix 3, second half). Before any mid-stream recovery, the position is looked up in the live receiver chain; if its receiver is still there and the offset falls inside it, the poll is retried. CPF7053 and CPF9801 take the same gate, so this closes the class rather than this instance. A failure to read the chain counts as "still available" — the destructive answer is the reset, so a connection problem must never be able to produce one.

**`fromBeginning` is only a position with no offset at all** (fix 4). An explicit zero offset that names a receiver is refused on sight: no receiver list read, no range resolved. It used to resolve to the oldest retained receiver, silently.

**The refusals are logged once per occurrence.** The inversion recurs at every receiver roll for up to the delayed-head interval, so on a journal rolling every 7-17 minutes #80's `ERROR` per poll buries the genuine cases. First occurrence is a WARN carrying the delta, repeats are DEBUG, and it escalates to ERROR once one refusal has held for ten polls — at that point streaming really has stopped advancing.

README updated with the new gate.

## Test

`mvn test -DskipITs` — 293 tests, 0 failures.

The tests the issue asks for, at the root cause rather than the guard:

- `aReceiverRollFollowedByTheNextPollNeverInvertsTheRange` — the sequence poll by poll: live list at 2050, delayed head at 2020 then 2030, position committed from the end of each range. Fails on the unpatched roll branch with `it resolved 2050`.
- `paginateInSameReceiverReturnsNothingWhenTheHeadIsBehindThePosition` — fails with the inverted `PositionRange[... start=3550, end=3500]`.
- `RetrieveJournalInvalidRangeTest` — a CPF7054 from a range `findRange` produced does not escape `retrieveJournal`, does escape once it persists, and a poll that reads its range forgets the refusals before it.
- `As400RpcConnectionLogPositionTest` — the chain lookup in all four cases, including "a failure to look is not a pruned position".
- `As400StreamingChangeEventSourceRecoveryTest` — a position still in the chain is retried and `setPosition` is never called; a position that has gone is still recovered, for both exception types.

Each one was checked to fail with its own fix reverted.

## Not in here

**Shipping the guard is still the action that stops the resets now.** The deployments that rewound run a 2026-09-01 image; `effbde9` is tagged and deployed nowhere.

**Validate on a fast-rolling journal.** The defect needs receivers rolling every few minutes. The control group in the issue — four connectors whose journals roll every 148-301 minutes, two of them across a full night, zero rewinds — is what a fix validated against a slow-rolling journal would be indistinguishable from.

Two rolls inside one delay window can still overshoot (#82's own "left alone" note); the guard from #80 covers it by stalling loudly instead of rewinding.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
